### PR TITLE
Add help menu for file download instructions

### DIFF
--- a/SPHMMaker/Form1.Designer.cs
+++ b/SPHMMaker/Form1.Designer.cs
@@ -121,6 +121,8 @@ namespace SPHMMaker
             saveDatapackToolStripMenuItem = new ToolStripMenuItem();
             loadDatapackToolStripMenuItem = new ToolStripMenuItem();
             exitToolStripMenuItem = new ToolStripMenuItem();
+            helpToolStripMenuItem = new ToolStripMenuItem();
+            fileDownloadInstructionsToolStripMenuItem = new ToolStripMenuItem();
             toolTip1 = new ToolTip(components);
             MainTab.SuspendLayout();
             ItemPageTab.SuspendLayout();
@@ -1046,7 +1048,7 @@ namespace SPHMMaker
             // 
             // menuStrip1
             // 
-            menuStrip1.Items.AddRange(new ToolStripItem[] { fileToolStripMenuItem });
+            menuStrip1.Items.AddRange(new ToolStripItem[] { fileToolStripMenuItem, helpToolStripMenuItem });
             menuStrip1.Location = new Point(0, 0);
             menuStrip1.Name = "menuStrip1";
             menuStrip1.Size = new Size(968, 24);
@@ -1074,15 +1076,29 @@ namespace SPHMMaker
             loadDatapackToolStripMenuItem.Size = new Size(190, 22);
             loadDatapackToolStripMenuItem.Text = "Load Datapack";
             loadDatapackToolStripMenuItem.Click += loadDatapackToolStripMenuItem_Click;
-            // 
+            //
             // exitToolStripMenuItem
-            // 
+            //
             exitToolStripMenuItem.Name = "exitToolStripMenuItem";
             exitToolStripMenuItem.Size = new Size(190, 22);
             exitToolStripMenuItem.Text = "Exit";
-            // 
+            //
+            // helpToolStripMenuItem
+            //
+            helpToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { fileDownloadInstructionsToolStripMenuItem });
+            helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            helpToolStripMenuItem.Size = new Size(44, 20);
+            helpToolStripMenuItem.Text = "Help";
+            //
+            // fileDownloadInstructionsToolStripMenuItem
+            //
+            fileDownloadInstructionsToolStripMenuItem.Name = "fileDownloadInstructionsToolStripMenuItem";
+            fileDownloadInstructionsToolStripMenuItem.Size = new Size(208, 22);
+            fileDownloadInstructionsToolStripMenuItem.Text = "File Download Instructions";
+            fileDownloadInstructionsToolStripMenuItem.Click += fileDownloadInstructionsToolStripMenuItem_Click;
+            //
             // Form1
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(968, 539);
@@ -1176,6 +1192,8 @@ namespace SPHMMaker
         private ToolStripMenuItem saveDatapackToolStripMenuItem;
         private ToolStripMenuItem loadDatapackToolStripMenuItem;
         private ToolStripMenuItem exitToolStripMenuItem;
+        private ToolStripMenuItem helpToolStripMenuItem;
+        private ToolStripMenuItem fileDownloadInstructionsToolStripMenuItem;
         private Button EditItemButton;
         private Button OverrideItemButton;
         private ToolTip toolTip1;

--- a/SPHMMaker/Form1.cs
+++ b/SPHMMaker/Form1.cs
@@ -117,5 +117,17 @@ namespace SPHMMaker
 
             MessageBox.Show(tooltip);
         }
+
+        private void fileDownloadInstructionsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            string instructions = "To download files that are shared in the chat:" + Environment.NewLine +
+                Environment.NewLine +
+                "1. Hover the message that contains the attachment and select the download icon." + Environment.NewLine +
+                "2. Pick a destination on your computer when the save dialog appears." + Environment.NewLine +
+                "3. After the download finishes, open the saved file from the chosen folder." + Environment.NewLine +
+                "4. If the download is a compressed archive (.zip), extract it before importing it into the game.";
+
+            MessageBox.Show(instructions, "File Download Instructions", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a Help menu entry that shows the chat file download instructions inside the editor

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de7cff0940833191bf5bd240cfe0b7