### PR TITLE
Add tiles tab for editing tile data

### DIFF
--- a/SPHMMaker/MainForm.Designer.cs
+++ b/SPHMMaker/MainForm.Designer.cs
@@ -37,6 +37,24 @@ namespace SPHMMaker
             itemSelectBoxLabel = new Label();
             MainTab = new TabControl();
             ItemPageTab = new TabPage();
+            TilesPageTab = new TabPage();
+            tileDetailsGroup = new GroupBox();
+            tileResetButton = new Button();
+            tileSaveButton = new Button();
+            tileCreateButton = new Button();
+            tileNotesInput = new RichTextBox();
+            tileNotesLabel = new Label();
+            tileMovementCostInput = new NumericUpDown();
+            tileMovementCostLabel = new Label();
+            tileWalkableCheckbox = new CheckBox();
+            tileTextureInput = new TextBox();
+            tileTextureLabel = new Label();
+            tileNameInput = new TextBox();
+            tileNameLabel = new Label();
+            tileIdInput = new NumericUpDown();
+            tileIdLabel = new Label();
+            tileListLabel = new Label();
+            tileList = new ListBox();
             OverrideItemButton = new Button();
             EditItemButton = new Button();
             itemWindowTabControl = new TabControl();
@@ -126,6 +144,8 @@ namespace SPHMMaker
             toolTip1 = new ToolTip(components);
             MainTab.SuspendLayout();
             ItemPageTab.SuspendLayout();
+            TilesPageTab.SuspendLayout();
+            tileDetailsGroup.SuspendLayout();
             itemWindowTabControl.SuspendLayout();
             createItemPage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)goldCostCounter).BeginInit();
@@ -163,6 +183,8 @@ namespace SPHMMaker
             descriptionTab.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)itemMaxCountSetter).BeginInit();
             itemEffectTab.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)tileMovementCostInput).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)tileIdInput).BeginInit();
             menuStrip1.SuspendLayout();
             SuspendLayout();
             // 
@@ -204,6 +226,7 @@ namespace SPHMMaker
             // MainTab
             // 
             MainTab.Controls.Add(ItemPageTab);
+            MainTab.Controls.Add(TilesPageTab);
             MainTab.Controls.Add(otherPage);
             MainTab.Location = new Point(0, 27);
             MainTab.Name = "MainTab";
@@ -225,9 +248,187 @@ namespace SPHMMaker
             ItemPageTab.TabIndex = 0;
             ItemPageTab.Text = "Items";
             ItemPageTab.UseVisualStyleBackColor = true;
-            // 
+            //
+            // TilesPageTab
+            //
+            TilesPageTab.Controls.Add(tileDetailsGroup);
+            TilesPageTab.Controls.Add(tileListLabel);
+            TilesPageTab.Controls.Add(tileList);
+            TilesPageTab.Location = new Point(4, 24);
+            TilesPageTab.Name = "TilesPageTab";
+            TilesPageTab.Padding = new Padding(3);
+            TilesPageTab.Size = new Size(792, 483);
+            TilesPageTab.TabIndex = 1;
+            TilesPageTab.Text = "Tiles";
+            TilesPageTab.UseVisualStyleBackColor = true;
+            //
+            // tileDetailsGroup
+            //
+            tileDetailsGroup.Controls.Add(tileResetButton);
+            tileDetailsGroup.Controls.Add(tileSaveButton);
+            tileDetailsGroup.Controls.Add(tileCreateButton);
+            tileDetailsGroup.Controls.Add(tileNotesInput);
+            tileDetailsGroup.Controls.Add(tileNotesLabel);
+            tileDetailsGroup.Controls.Add(tileMovementCostInput);
+            tileDetailsGroup.Controls.Add(tileMovementCostLabel);
+            tileDetailsGroup.Controls.Add(tileWalkableCheckbox);
+            tileDetailsGroup.Controls.Add(tileTextureInput);
+            tileDetailsGroup.Controls.Add(tileTextureLabel);
+            tileDetailsGroup.Controls.Add(tileNameInput);
+            tileDetailsGroup.Controls.Add(tileNameLabel);
+            tileDetailsGroup.Controls.Add(tileIdInput);
+            tileDetailsGroup.Controls.Add(tileIdLabel);
+            tileDetailsGroup.Location = new Point(6, 6);
+            tileDetailsGroup.Name = "tileDetailsGroup";
+            tileDetailsGroup.Size = new Size(570, 471);
+            tileDetailsGroup.TabIndex = 0;
+            tileDetailsGroup.TabStop = false;
+            tileDetailsGroup.Text = "Tile Details";
+            //
+            // tileResetButton
+            //
+            tileResetButton.Location = new Point(352, 370);
+            tileResetButton.Name = "tileResetButton";
+            tileResetButton.Size = new Size(110, 27);
+            tileResetButton.TabIndex = 13;
+            tileResetButton.Text = "Reset";
+            tileResetButton.UseVisualStyleBackColor = true;
+            tileResetButton.Click += tileResetButton_Click;
+            //
+            // tileSaveButton
+            //
+            tileSaveButton.Location = new Point(236, 370);
+            tileSaveButton.Name = "tileSaveButton";
+            tileSaveButton.Size = new Size(110, 27);
+            tileSaveButton.TabIndex = 12;
+            tileSaveButton.Text = "Save Changes";
+            tileSaveButton.UseVisualStyleBackColor = true;
+            tileSaveButton.Click += tileSaveButton_Click;
+            //
+            // tileCreateButton
+            //
+            tileCreateButton.Location = new Point(120, 370);
+            tileCreateButton.Name = "tileCreateButton";
+            tileCreateButton.Size = new Size(110, 27);
+            tileCreateButton.TabIndex = 11;
+            tileCreateButton.Text = "Create Tile";
+            tileCreateButton.UseVisualStyleBackColor = true;
+            tileCreateButton.Click += tileCreateButton_Click;
+            //
+            // tileNotesInput
+            //
+            tileNotesInput.Location = new Point(120, 181);
+            tileNotesInput.Name = "tileNotesInput";
+            tileNotesInput.Size = new Size(414, 168);
+            tileNotesInput.TabIndex = 10;
+            tileNotesInput.Text = "";
+            //
+            // tileNotesLabel
+            //
+            tileNotesLabel.AutoSize = true;
+            tileNotesLabel.Location = new Point(12, 181);
+            tileNotesLabel.Name = "tileNotesLabel";
+            tileNotesLabel.Size = new Size(41, 15);
+            tileNotesLabel.TabIndex = 9;
+            tileNotesLabel.Text = "Notes:";
+            //
+            // tileMovementCostInput
+            //
+            tileMovementCostInput.Location = new Point(120, 146);
+            tileMovementCostInput.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
+            tileMovementCostInput.Name = "tileMovementCostInput";
+            tileMovementCostInput.Size = new Size(120, 23);
+            tileMovementCostInput.TabIndex = 8;
+            tileMovementCostInput.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            //
+            // tileMovementCostLabel
+            //
+            tileMovementCostLabel.AutoSize = true;
+            tileMovementCostLabel.Location = new Point(12, 150);
+            tileMovementCostLabel.Name = "tileMovementCostLabel";
+            tileMovementCostLabel.Size = new Size(93, 15);
+            tileMovementCostLabel.TabIndex = 7;
+            tileMovementCostLabel.Text = "Movement cost:";
+            //
+            // tileWalkableCheckbox
+            //
+            tileWalkableCheckbox.AutoSize = true;
+            tileWalkableCheckbox.Location = new Point(120, 118);
+            tileWalkableCheckbox.Name = "tileWalkableCheckbox";
+            tileWalkableCheckbox.Size = new Size(76, 19);
+            tileWalkableCheckbox.TabIndex = 6;
+            tileWalkableCheckbox.Text = "Walkable";
+            tileWalkableCheckbox.UseVisualStyleBackColor = true;
+            //
+            // tileTextureInput
+            //
+            tileTextureInput.Location = new Point(120, 87);
+            tileTextureInput.Name = "tileTextureInput";
+            tileTextureInput.Size = new Size(250, 23);
+            tileTextureInput.TabIndex = 5;
+            //
+            // tileTextureLabel
+            //
+            tileTextureLabel.AutoSize = true;
+            tileTextureLabel.Location = new Point(12, 90);
+            tileTextureLabel.Name = "tileTextureLabel";
+            tileTextureLabel.Size = new Size(48, 15);
+            tileTextureLabel.TabIndex = 4;
+            tileTextureLabel.Text = "Texture:";
+            //
+            // tileNameInput
+            //
+            tileNameInput.Location = new Point(120, 56);
+            tileNameInput.Name = "tileNameInput";
+            tileNameInput.Size = new Size(250, 23);
+            tileNameInput.TabIndex = 3;
+            //
+            // tileNameLabel
+            //
+            tileNameLabel.AutoSize = true;
+            tileNameLabel.Location = new Point(12, 59);
+            tileNameLabel.Name = "tileNameLabel";
+            tileNameLabel.Size = new Size(42, 15);
+            tileNameLabel.TabIndex = 2;
+            tileNameLabel.Text = "Name:";
+            //
+            // tileIdInput
+            //
+            tileIdInput.Location = new Point(120, 24);
+            tileIdInput.Maximum = new decimal(new int[] { 9999, 0, 0, 0 });
+            tileIdInput.Name = "tileIdInput";
+            tileIdInput.Size = new Size(120, 23);
+            tileIdInput.TabIndex = 1;
+            //
+            // tileIdLabel
+            //
+            tileIdLabel.AutoSize = true;
+            tileIdLabel.Location = new Point(12, 28);
+            tileIdLabel.Name = "tileIdLabel";
+            tileIdLabel.Size = new Size(22, 15);
+            tileIdLabel.TabIndex = 0;
+            tileIdLabel.Text = "ID:";
+            //
+            // tileListLabel
+            //
+            tileListLabel.AutoSize = true;
+            tileListLabel.Location = new Point(582, 12);
+            tileListLabel.Name = "tileListLabel";
+            tileListLabel.Size = new Size(35, 15);
+            tileListLabel.TabIndex = 1;
+            tileListLabel.Text = "Tiles:";
+            //
+            // tileList
+            //
+            tileList.FormattingEnabled = true;
+            tileList.ItemHeight = 15;
+            tileList.Location = new Point(582, 30);
+            tileList.Name = "tileList";
+            tileList.Size = new Size(202, 364);
+            tileList.TabIndex = 2;
+            //
             // OverrideItemButton
-            // 
+            //
             OverrideItemButton.Location = new Point(684, 395);
             OverrideItemButton.Name = "OverrideItemButton";
             OverrideItemButton.Size = new Size(100, 24);
@@ -1042,7 +1243,7 @@ namespace SPHMMaker
             otherPage.Name = "otherPage";
             otherPage.Padding = new Padding(3);
             otherPage.Size = new Size(792, 483);
-            otherPage.TabIndex = 1;
+            otherPage.TabIndex = 2;
             otherPage.Text = "??";
             otherPage.UseVisualStyleBackColor = true;
             // 
@@ -1159,6 +1360,12 @@ namespace SPHMMaker
             ((System.ComponentModel.ISupportInitialize)itemMaxCountSetter).EndInit();
             itemEffectTab.ResumeLayout(false);
             itemEffectTab.PerformLayout();
+            tileDetailsGroup.ResumeLayout(false);
+            tileDetailsGroup.PerformLayout();
+            TilesPageTab.ResumeLayout(false);
+            TilesPageTab.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)tileMovementCostInput).EndInit();
+            ((System.ComponentModel.ISupportInitialize)tileIdInput).EndInit();
             menuStrip1.ResumeLayout(false);
             menuStrip1.PerformLayout();
             ResumeLayout(false);
@@ -1173,7 +1380,25 @@ namespace SPHMMaker
         private Label itemSelectBoxLabel;
         private TabControl MainTab;
         private TabPage ItemPageTab;
+        private TabPage TilesPageTab;
         private TabPage otherPage;
+        private GroupBox tileDetailsGroup;
+        private Button tileResetButton;
+        private Button tileSaveButton;
+        private Button tileCreateButton;
+        private RichTextBox tileNotesInput;
+        private Label tileNotesLabel;
+        private NumericUpDown tileMovementCostInput;
+        private Label tileMovementCostLabel;
+        private CheckBox tileWalkableCheckbox;
+        private TextBox tileTextureInput;
+        private Label tileTextureLabel;
+        private TextBox tileNameInput;
+        private Label tileNameLabel;
+        private NumericUpDown tileIdInput;
+        private Label tileIdLabel;
+        private Label tileListLabel;
+        private ListBox tileList;
         private TabControl itemWindowTabControl;
         private TabPage createItemPage;
         private TabPage itemEffectTab;

--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -1,6 +1,9 @@
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using SPHMMaker.Items;
+using SPHMMaker.Tiles;
 
 namespace SPHMMaker
 {
@@ -12,6 +15,7 @@ namespace SPHMMaker
         static extern bool AllocConsole();
 
         int editingItem = -1;
+        int editingTile = -1;
 
 
         public MainForm()
@@ -21,6 +25,7 @@ namespace SPHMMaker
             AllocConsole();
 
             InitializeItems();
+            InitializeTiles();
         }
         private void loadDatapackToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -50,6 +55,7 @@ namespace SPHMMaker
             }
 
             ItemManager.Load(path + "\\Items");
+            TileManager.Load(path + "\\Tiles");
         }
 
         private void saveDatapackToolStripMenuItem_Click(object sender, EventArgs e)
@@ -129,5 +135,137 @@ namespace SPHMMaker
 
             MessageBox.Show(instructions, "File Download Instructions", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
+
+        private TileData? FoldDataIntoTile
+        {
+            get
+            {
+                int id = (int)tileIdInput.Value;
+                string name = tileNameInput.Text;
+                string texture = tileTextureInput.Text;
+                bool isWalkable = tileWalkableCheckbox.Checked;
+                int movementCost = (int)tileMovementCostInput.Value;
+                string notes = tileNotesInput.Text;
+
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    MessageBox.Show("Tile name cannot be empty.");
+                    return null;
+                }
+
+                if (string.IsNullOrWhiteSpace(texture))
+                {
+                    MessageBox.Show("Texture name cannot be empty.");
+                    return null;
+                }
+
+                if (!TileManager.FreeIdCheck(id) && (editingTile < 0 || TileManager.Tiles[editingTile].ID != id))
+                {
+                    MessageBox.Show("Tile ID must be unique.");
+                    return null;
+                }
+
+                return new TileData(id, name, texture, isWalkable, movementCost, notes);
+            }
+        }
+
+        private void InitializeTiles()
+        {
+            TileManager.SetListBox(tileList);
+            if (!TileManager.Load(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Tiles")))
+            {
+                TileManager.LoadDefaults();
+            }
+
+            tileList.SelectedIndexChanged += tileList_SelectedIndexChanged;
+            ResetTileEditor();
+        }
+
+        private int GetNextTileId()
+        {
+            int highest = -1;
+            foreach (TileData tile in TileManager.Tiles)
+            {
+                if (tile.ID > highest)
+                {
+                    highest = tile.ID;
+                }
+            }
+
+            return highest + 1;
+        }
+
+        private void ResetTileEditor()
+        {
+            editingTile = -1;
+            int nextId = GetNextTileId();
+            if (nextId < tileIdInput.Minimum)
+            {
+                nextId = (int)tileIdInput.Minimum;
+            }
+            if (nextId > tileIdInput.Maximum)
+            {
+                nextId = (int)tileIdInput.Maximum;
+            }
+
+            tileIdInput.Value = nextId;
+            tileNameInput.Text = string.Empty;
+            tileTextureInput.Text = string.Empty;
+            tileWalkableCheckbox.Checked = true;
+            tileMovementCostInput.Value = Math.Max(tileMovementCostInput.Minimum, 1m);
+            tileNotesInput.Text = string.Empty;
+            tileList.ClearSelected();
+        }
+
+        private void tileList_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (tileList.SelectedItem is not TileData tile)
+            {
+                return;
+            }
+
+            editingTile = tileList.SelectedIndex;
+            tileIdInput.Value = Math.Min(Math.Max(tile.ID, (int)tileIdInput.Minimum), (int)tileIdInput.Maximum);
+            tileNameInput.Text = tile.Name;
+            tileTextureInput.Text = tile.Texture;
+            tileWalkableCheckbox.Checked = tile.IsWalkable;
+            int movementValue = Math.Min(Math.Max(tile.MovementCost, (int)tileMovementCostInput.Minimum), (int)tileMovementCostInput.Maximum);
+            tileMovementCostInput.Value = movementValue;
+            tileNotesInput.Text = tile.Notes;
+        }
+
+        private void tileCreateButton_Click(object sender, EventArgs e)
+        {
+            TileData? tile = FoldDataIntoTile;
+            if (tile is null)
+            {
+                return;
+            }
+
+            TileManager.CreateTile(tile);
+            tileList.SelectedItem = TileManager.Tiles.FirstOrDefault(t => t.ID == tile.ID);
+            ResetTileEditor();
+        }
+
+        private void tileSaveButton_Click(object sender, EventArgs e)
+        {
+            if (tileList.SelectedIndex < 0)
+            {
+                MessageBox.Show("Select a tile to update.");
+                return;
+            }
+
+            editingTile = tileList.SelectedIndex;
+            TileData? tile = FoldDataIntoTile;
+            if (tile is null)
+            {
+                return;
+            }
+
+            TileManager.OverrideTile(tileList.SelectedIndex, tile);
+            tileList.SelectedItem = TileManager.Tiles.FirstOrDefault(t => t.ID == tile.ID);
+        }
+
+        private void tileResetButton_Click(object sender, EventArgs e) => ResetTileEditor();
     }
 }

--- a/SPHMMaker/Tiles/TileData.cs
+++ b/SPHMMaker/Tiles/TileData.cs
@@ -1,0 +1,41 @@
+using System.Text;
+
+namespace SPHMMaker.Tiles
+{
+    public class TileData
+    {
+        public int ID { get; set; }
+        public string Name { get; set; }
+        public string Texture { get; set; }
+        public bool IsWalkable { get; set; }
+        public int MovementCost { get; set; }
+        public string Notes { get; set; }
+
+        public TileData()
+        {
+            Name = string.Empty;
+            Texture = string.Empty;
+            Notes = string.Empty;
+        }
+
+        public TileData(int id, string name, string texture, bool isWalkable, int movementCost, string notes)
+        {
+            ID = id;
+            Name = name;
+            Texture = texture;
+            IsWalkable = isWalkable;
+            MovementCost = movementCost;
+            Notes = notes;
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.Append('[');
+            builder.Append(ID);
+            builder.Append("] ");
+            builder.Append(Name);
+            return builder.ToString();
+        }
+    }
+}

--- a/SPHMMaker/Tiles/TileManager.cs
+++ b/SPHMMaker/Tiles/TileManager.cs
@@ -1,0 +1,117 @@
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using Newtonsoft.Json;
+
+namespace SPHMMaker.Tiles
+{
+    internal static class TileManager
+    {
+        private static readonly JsonSerializerSettings SerializerSettings = new()
+        {
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            TypeNameHandling = TypeNameHandling.None
+        };
+
+        private static List<TileData> tiles = new();
+        private static ListBox? tileListBox;
+
+        public static ReadOnlyCollection<TileData> Tiles => tiles.AsReadOnly();
+
+        public static void SetListBox(ListBox listBox)
+        {
+            tileListBox = listBox;
+            RefreshDataSource();
+        }
+
+        public static void CreateTile(TileData tile)
+        {
+            tiles.Add(tile);
+            tiles = tiles.OrderBy(t => t.ID).ToList();
+            RefreshDataSource();
+        }
+
+        public static void OverrideTile(int index, TileData tile)
+        {
+            if (index < 0 || index >= tiles.Count)
+            {
+                return;
+            }
+
+            tiles[index] = tile;
+            tiles = tiles.OrderBy(t => t.ID).ToList();
+            RefreshDataSource();
+        }
+
+        public static bool FreeIdCheck(int id) => tiles.All(t => t.ID != id);
+
+        public static void LoadDefaults()
+        {
+            if (tiles.Count > 0)
+            {
+                return;
+            }
+
+            tiles = new List<TileData>
+            {
+                new TileData(0, "Grass", "grass", true, 1, "Standard grassy terrain."),
+                new TileData(1, "Dirt", "dirt", true, 1, "Lightly trodden path."),
+                new TileData(2, "Stone", "stone", true, 1, "Worked stone floor."),
+                new TileData(3, "Water", "water", false, 0, "Cannot be traversed without special abilities."),
+                new TileData(4, "Lava", "lava", false, 0, "Deadly lava tile."),
+                new TileData(5, "Snow", "snow", true, 2, "Slows movement slightly."),
+            };
+            RefreshDataSource();
+        }
+
+        public static bool Load(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                LoadDefaults();
+                return false;
+            }
+
+            var files = Directory.GetFiles(path, "*.json", SearchOption.TopDirectoryOnly);
+            if (files.Length == 0)
+            {
+                LoadDefaults();
+                return false;
+            }
+
+            var loadedTiles = new List<TileData>();
+            foreach (var file in files)
+            {
+                var rawData = File.ReadAllText(file);
+                var tile = JsonConvert.DeserializeObject<TileData>(rawData, SerializerSettings);
+                if (tile != null)
+                {
+                    loadedTiles.Add(tile);
+                }
+            }
+
+            if (loadedTiles.Count == 0)
+            {
+                LoadDefaults();
+                return false;
+            }
+
+            tiles = loadedTiles.OrderBy(t => t.ID).ToList();
+            RefreshDataSource();
+            return true;
+        }
+
+        private static void RefreshDataSource()
+        {
+            if (tileListBox == null)
+            {
+                return;
+            }
+
+            tileListBox.DataSource = null;
+            tileListBox.DataSource = tiles;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Tiles tab to the main window so tile properties can be reviewed and edited alongside the existing items tab
- introduce TileData and TileManager classes to hold tile metadata, provide default entries, and keep the list box in sync
- hook datapack loading to populate tiles from a Tiles directory when available

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de8d527764833187490c2fb52aea30