### PR TITLE
Add loot table editor with probability visualization

### DIFF
--- a/SPHMMaker/Loot/LootEntry.cs
+++ b/SPHMMaker/Loot/LootEntry.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace SPHMMaker.Loot
+{
+    public class LootEntry : INotifyPropertyChanged
+    {
+        int itemId;
+        double dropChance;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public int ItemId
+        {
+            get => itemId;
+            set
+            {
+                if (itemId == value)
+                {
+                    return;
+                }
+
+                itemId = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public double DropChance
+        {
+            get => dropChance;
+            set
+            {
+                double clamped = Math.Clamp(value, 0d, 1d);
+                if (Math.Abs(dropChance - clamped) < double.Epsilon)
+                {
+                    return;
+                }
+
+                dropChance = clamped;
+                OnPropertyChanged();
+            }
+        }
+
+        void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/SPHMMaker/Loot/LootManager.cs
+++ b/SPHMMaker/Loot/LootManager.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+
+namespace SPHMMaker.Loot
+{
+    internal static class LootManager
+    {
+        static readonly BindingList<LootTable> lootTables = new();
+
+        public static BindingList<LootTable> LootTables => lootTables;
+
+        public static LootTable CreateLootTable(int id, string name)
+        {
+            if (ContainsId(id))
+            {
+                throw new InvalidOperationException($"Loot table with id {id} already exists.");
+            }
+
+            string resolvedName = string.IsNullOrWhiteSpace(name) ? $"Loot Table {id}" : name.Trim();
+            LootTable lootTable = new(id, resolvedName);
+            lootTables.Add(lootTable);
+            return lootTable;
+        }
+
+        public static bool ContainsId(int id) => lootTables.Any(t => t.Id == id);
+
+        public static void Remove(LootTable lootTable)
+        {
+            lootTables.Remove(lootTable);
+        }
+    }
+}

--- a/SPHMMaker/Loot/LootProbability.cs
+++ b/SPHMMaker/Loot/LootProbability.cs
@@ -1,0 +1,71 @@
+namespace SPHMMaker.Loot
+{
+    public static class LootProbability
+    {
+        public static IReadOnlyList<LootProbabilityPoint> CalculateDistribution(LootEntry entry, int killCount)
+        {
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            if (killCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(killCount));
+            }
+
+            double p = Math.Clamp(entry.DropChance, 0d, 1d);
+            List<LootProbabilityPoint> result = new(killCount + 1);
+
+            for (int i = 0; i <= killCount; i++)
+            {
+                double probability = BinomialProbability(killCount, i, p);
+                result.Add(new LootProbabilityPoint(i, probability));
+            }
+
+            return result;
+        }
+
+        static double BinomialProbability(int n, int k, double p)
+        {
+            if (p <= 0)
+            {
+                return k == 0 ? 1d : 0d;
+            }
+
+            if (p >= 1)
+            {
+                return k == n ? 1d : 0d;
+            }
+
+            double combinations = BinomialCoefficient(n, k);
+            return combinations * Math.Pow(p, k) * Math.Pow(1 - p, n - k);
+        }
+
+        static double BinomialCoefficient(int n, int k)
+        {
+            if (k < 0 || k > n)
+            {
+                return 0;
+            }
+
+            if (k == 0 || k == n)
+            {
+                return 1;
+            }
+
+            k = Math.Min(k, n - k);
+
+            double c = 1d;
+            for (int i = 0; i < k; i++)
+            {
+                c *= (n - i);
+                c /= (i + 1);
+            }
+
+            return c;
+        }
+    }
+
+    public readonly record struct LootProbabilityPoint(int Drops, double Probability);
+}

--- a/SPHMMaker/Loot/LootTable.cs
+++ b/SPHMMaker/Loot/LootTable.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+
+namespace SPHMMaker.Loot
+{
+    public class LootTable : INotifyPropertyChanged
+    {
+        int id;
+        string name;
+
+        public LootTable()
+        {
+            name = string.Empty;
+            Entries = new BindingList<LootEntry>();
+        }
+
+        public LootTable(int id, string name) : this()
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public int Id
+        {
+            get => id;
+            set
+            {
+                if (id == value)
+                {
+                    return;
+                }
+
+                id = value;
+                OnPropertyChanged(nameof(Id));
+                OnPropertyChanged(nameof(Display));
+            }
+        }
+
+        public string Name
+        {
+            get => name;
+            set
+            {
+                if (name == value)
+                {
+                    return;
+                }
+
+                name = value;
+                OnPropertyChanged(nameof(Name));
+                OnPropertyChanged(nameof(Display));
+            }
+        }
+
+        public BindingList<LootEntry> Entries { get; }
+
+        public string Display => $"{Id}: {Name}";
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public override string ToString() => Display;
+    }
+}

--- a/SPHMMaker/MainForm.Designer.cs
+++ b/SPHMMaker/MainForm.Designer.cs
@@ -31,6 +31,9 @@ namespace SPHMMaker
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea1 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
+            System.Windows.Forms.DataVisualization.Charting.Legend legend1 = new System.Windows.Forms.DataVisualization.Charting.Legend();
             itemNameInput = new TextBox();
             items = new ListBox();
             itemNameLabel = new Label();
@@ -115,6 +118,21 @@ namespace SPHMMaker
             label1 = new Label();
             listBox2 = new ListBox();
             listBox1 = new ListBox();
+            lootTabPage = new TabPage();
+            lootProbabilityChart = new System.Windows.Forms.DataVisualization.Charting.Chart();
+            lootKillCountLabel = new Label();
+            lootKillCountSetter = new NumericUpDown();
+            lootEntriesGrid = new DataGridView();
+            lootDropChanceColumn = new DataGridViewTextBoxColumn();
+            lootItemIdColumn = new DataGridViewTextBoxColumn();
+            lootTableNameInput = new TextBox();
+            lootTableNameLabel = new Label();
+            lootTableIdInput = new NumericUpDown();
+            lootTableIdLabel = new Label();
+            lootRemoveTableButton = new Button();
+            lootAddTableButton = new Button();
+            lootTableListBox = new ListBox();
+            lootTablesLabel = new Label();
             otherPage = new TabPage();
             menuStrip1 = new MenuStrip();
             fileToolStripMenuItem = new ToolStripMenuItem();
@@ -163,6 +181,11 @@ namespace SPHMMaker
             descriptionTab.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)itemMaxCountSetter).BeginInit();
             itemEffectTab.SuspendLayout();
+            lootTabPage.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)lootProbabilityChart).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)lootKillCountSetter).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)lootEntriesGrid).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)lootTableIdInput).BeginInit();
             menuStrip1.SuspendLayout();
             SuspendLayout();
             // 
@@ -204,6 +227,7 @@ namespace SPHMMaker
             // MainTab
             // 
             MainTab.Controls.Add(ItemPageTab);
+            MainTab.Controls.Add(lootTabPage);
             MainTab.Controls.Add(otherPage);
             MainTab.Location = new Point(0, 27);
             MainTab.Name = "MainTab";
@@ -999,45 +1023,207 @@ namespace SPHMMaker
             itemEffectTab.TabIndex = 1;
             itemEffectTab.Text = "Item Effects";
             itemEffectTab.UseVisualStyleBackColor = true;
-            // 
+            //
             // label2
-            // 
+            //
             label2.AutoSize = true;
             label2.Location = new Point(306, 7);
             label2.Name = "label2";
             label2.Size = new Size(119, 15);
             label2.TabIndex = 3;
             label2.Text = "Selected Item Effects:";
-            // 
+            //
             // label1
-            // 
+            //
             label1.AutoSize = true;
             label1.Location = new Point(18, 5);
             label1.Name = "label1";
             label1.Size = new Size(62, 15);
             label1.TabIndex = 2;
             label1.Text = "All effects:";
-            // 
+            //
             // listBox2
-            // 
+            //
             listBox2.FormattingEnabled = true;
             listBox2.ItemHeight = 15;
             listBox2.Location = new Point(305, 30);
             listBox2.Name = "listBox2";
             listBox2.Size = new Size(231, 334);
             listBox2.TabIndex = 1;
-            // 
+            //
             // listBox1
-            // 
+            //
             listBox1.FormattingEnabled = true;
             listBox1.ItemHeight = 15;
             listBox1.Location = new Point(25, 30);
             listBox1.Name = "listBox1";
             listBox1.Size = new Size(231, 334);
             listBox1.TabIndex = 0;
-            // 
+            //
+            // lootTabPage
+            //
+            lootTabPage.Controls.Add(lootProbabilityChart);
+            lootTabPage.Controls.Add(lootKillCountLabel);
+            lootTabPage.Controls.Add(lootKillCountSetter);
+            lootTabPage.Controls.Add(lootEntriesGrid);
+            lootTabPage.Controls.Add(lootTableNameInput);
+            lootTabPage.Controls.Add(lootTableNameLabel);
+            lootTabPage.Controls.Add(lootTableIdInput);
+            lootTabPage.Controls.Add(lootTableIdLabel);
+            lootTabPage.Controls.Add(lootRemoveTableButton);
+            lootTabPage.Controls.Add(lootAddTableButton);
+            lootTabPage.Controls.Add(lootTableListBox);
+            lootTabPage.Controls.Add(lootTablesLabel);
+            lootTabPage.Location = new Point(4, 24);
+            lootTabPage.Name = "lootTabPage";
+            lootTabPage.Padding = new Padding(3);
+            lootTabPage.Size = new Size(792, 483);
+            lootTabPage.TabIndex = 2;
+            lootTabPage.Text = "Loot";
+            lootTabPage.UseVisualStyleBackColor = true;
+            //
+            // lootProbabilityChart
+            //
+            lootProbabilityChart.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            chartArea1.Name = "ChartArea1";
+            lootProbabilityChart.ChartAreas.Add(chartArea1);
+            legend1.Name = "Legend1";
+            lootProbabilityChart.Legends.Add(legend1);
+            lootProbabilityChart.Location = new Point(220, 246);
+            lootProbabilityChart.Name = "lootProbabilityChart";
+            lootProbabilityChart.Size = new Size(556, 219);
+            lootProbabilityChart.TabIndex = 11;
+            lootProbabilityChart.Text = "lootProbabilityChart";
+            //
+            // lootKillCountLabel
+            //
+            lootKillCountLabel.AutoSize = true;
+            lootKillCountLabel.Location = new Point(220, 220);
+            lootKillCountLabel.Name = "lootKillCountLabel";
+            lootKillCountLabel.Size = new Size(95, 15);
+            lootKillCountLabel.TabIndex = 9;
+            lootKillCountLabel.Text = "Simulation kills:";
+            //
+            // lootKillCountSetter
+            //
+            lootKillCountSetter.Location = new Point(321, 218);
+            lootKillCountSetter.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            lootKillCountSetter.Minimum = new decimal(new int[] { 0, 0, 0, 0 });
+            lootKillCountSetter.Name = "lootKillCountSetter";
+            lootKillCountSetter.Size = new Size(80, 23);
+            lootKillCountSetter.TabIndex = 10;
+            lootKillCountSetter.Value = new decimal(new int[] { 10, 0, 0, 0 });
+            //
+            // lootEntriesGrid
+            //
+            lootEntriesGrid.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            lootEntriesGrid.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            lootEntriesGrid.Columns.AddRange(new DataGridViewColumn[] { lootItemIdColumn, lootDropChanceColumn });
+            lootEntriesGrid.Location = new Point(220, 64);
+            lootEntriesGrid.MultiSelect = false;
+            lootEntriesGrid.Name = "lootEntriesGrid";
+            lootEntriesGrid.RowHeadersVisible = false;
+            lootEntriesGrid.RowTemplate.Height = 25;
+            lootEntriesGrid.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
+            lootEntriesGrid.Size = new Size(556, 150);
+            lootEntriesGrid.TabIndex = 8;
+            //
+            // lootDropChanceColumn
+            //
+            lootDropChanceColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            lootDropChanceColumn.DataPropertyName = "DropChance";
+            lootDropChanceColumn.FillWeight = 60F;
+            dataGridViewCellStyle1.Alignment = DataGridViewContentAlignment.MiddleRight;
+            dataGridViewCellStyle1.Format = "P2";
+            dataGridViewCellStyle1.NullValue = null;
+            lootDropChanceColumn.DefaultCellStyle = dataGridViewCellStyle1;
+            lootDropChanceColumn.HeaderText = "Drop chance";
+            lootDropChanceColumn.Name = "lootDropChanceColumn";
+            lootDropChanceColumn.SortMode = DataGridViewColumnSortMode.NotSortable;
+            lootDropChanceColumn.ValueType = typeof(double);
+            //
+            // lootItemIdColumn
+            //
+            lootItemIdColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            lootItemIdColumn.DataPropertyName = "ItemId";
+            lootItemIdColumn.FillWeight = 40F;
+            lootItemIdColumn.HeaderText = "Item ID";
+            lootItemIdColumn.MinimumWidth = 80;
+            lootItemIdColumn.Name = "lootItemIdColumn";
+            lootItemIdColumn.SortMode = DataGridViewColumnSortMode.NotSortable;
+            lootItemIdColumn.ValueType = typeof(int);
+            //
+            // lootTableNameInput
+            //
+            lootTableNameInput.Location = new Point(268, 33);
+            lootTableNameInput.Name = "lootTableNameInput";
+            lootTableNameInput.Size = new Size(250, 23);
+            lootTableNameInput.TabIndex = 6;
+            //
+            // lootTableNameLabel
+            //
+            lootTableNameLabel.AutoSize = true;
+            lootTableNameLabel.Location = new Point(220, 36);
+            lootTableNameLabel.Name = "lootTableNameLabel";
+            lootTableNameLabel.Size = new Size(45, 15);
+            lootTableNameLabel.TabIndex = 5;
+            lootTableNameLabel.Text = "Name:";
+            //
+            // lootTableIdInput
+            //
+            lootTableIdInput.Location = new Point(268, 6);
+            lootTableIdInput.Maximum = new decimal(new int[] { 999999, 0, 0, 0 });
+            lootTableIdInput.Name = "lootTableIdInput";
+            lootTableIdInput.Size = new Size(120, 23);
+            lootTableIdInput.TabIndex = 4;
+            //
+            // lootTableIdLabel
+            //
+            lootTableIdLabel.AutoSize = true;
+            lootTableIdLabel.Location = new Point(220, 8);
+            lootTableIdLabel.Name = "lootTableIdLabel";
+            lootTableIdLabel.Size = new Size(22, 15);
+            lootTableIdLabel.TabIndex = 3;
+            lootTableIdLabel.Text = "ID:";
+            //
+            // lootRemoveTableButton
+            //
+            lootRemoveTableButton.Location = new Point(110, 371);
+            lootRemoveTableButton.Name = "lootRemoveTableButton";
+            lootRemoveTableButton.Size = new Size(96, 23);
+            lootRemoveTableButton.TabIndex = 2;
+            lootRemoveTableButton.Text = "Remove";
+            lootRemoveTableButton.UseVisualStyleBackColor = true;
+            //
+            // lootAddTableButton
+            //
+            lootAddTableButton.Location = new Point(6, 371);
+            lootAddTableButton.Name = "lootAddTableButton";
+            lootAddTableButton.Size = new Size(96, 23);
+            lootAddTableButton.TabIndex = 1;
+            lootAddTableButton.Text = "Add table";
+            lootAddTableButton.UseVisualStyleBackColor = true;
+            //
+            // lootTableListBox
+            //
+            lootTableListBox.FormattingEnabled = true;
+            lootTableListBox.ItemHeight = 15;
+            lootTableListBox.Location = new Point(6, 26);
+            lootTableListBox.Name = "lootTableListBox";
+            lootTableListBox.Size = new Size(200, 334);
+            lootTableListBox.TabIndex = 0;
+            //
+            // lootTablesLabel
+            //
+            lootTablesLabel.AutoSize = true;
+            lootTablesLabel.Location = new Point(6, 8);
+            lootTablesLabel.Name = "lootTablesLabel";
+            lootTablesLabel.Size = new Size(70, 15);
+            lootTablesLabel.TabIndex = 0;
+            lootTablesLabel.Text = "Loot tables:";
+            //
             // otherPage
-            // 
+            //
             otherPage.Location = new Point(4, 24);
             otherPage.Name = "otherPage";
             otherPage.Padding = new Padding(3);
@@ -1159,6 +1345,12 @@ namespace SPHMMaker
             ((System.ComponentModel.ISupportInitialize)itemMaxCountSetter).EndInit();
             itemEffectTab.ResumeLayout(false);
             itemEffectTab.PerformLayout();
+            lootTabPage.ResumeLayout(false);
+            lootTabPage.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)lootProbabilityChart).EndInit();
+            ((System.ComponentModel.ISupportInitialize)lootKillCountSetter).EndInit();
+            ((System.ComponentModel.ISupportInitialize)lootEntriesGrid).EndInit();
+            ((System.ComponentModel.ISupportInitialize)lootTableIdInput).EndInit();
             menuStrip1.ResumeLayout(false);
             menuStrip1.PerformLayout();
             ResumeLayout(false);
@@ -1260,5 +1452,20 @@ namespace SPHMMaker
         private Label itemPotionMaximumLabel;
         private Label itemPotionMinimumLabel;
         private Button itemCheckGeneratedTooltip;
+        private System.Windows.Forms.DataVisualization.Charting.Chart lootProbabilityChart;
+        private Label lootKillCountLabel;
+        private NumericUpDown lootKillCountSetter;
+        private DataGridView lootEntriesGrid;
+        private DataGridViewTextBoxColumn lootDropChanceColumn;
+        private DataGridViewTextBoxColumn lootItemIdColumn;
+        private TextBox lootTableNameInput;
+        private Label lootTableNameLabel;
+        private NumericUpDown lootTableIdInput;
+        private Label lootTableIdLabel;
+        private Button lootRemoveTableButton;
+        private Button lootAddTableButton;
+        private ListBox lootTableListBox;
+        private Label lootTablesLabel;
+        private TabPage lootTabPage;
     }
 }

--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -1,6 +1,10 @@
+using System.ComponentModel;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using System.Windows.Forms.DataVisualization.Charting;
 using SPHMMaker.Items;
+using SPHMMaker.Loot;
 
 namespace SPHMMaker
 {
@@ -12,6 +16,7 @@ namespace SPHMMaker
         static extern bool AllocConsole();
 
         int editingItem = -1;
+        LootTable? selectedLootTable;
 
 
         public MainForm()
@@ -21,6 +26,7 @@ namespace SPHMMaker
             AllocConsole();
 
             InitializeItems();
+            InitializeLoot();
         }
         private void loadDatapackToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -128,6 +134,189 @@ namespace SPHMMaker
                 "4. If the download is a compressed archive (.zip), extract it before importing it into the game.";
 
             MessageBox.Show(instructions, "File Download Instructions", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        void InitializeLoot()
+        {
+            lootTableListBox.DisplayMember = nameof(LootTable.Display);
+            lootTableListBox.DataSource = LootManager.LootTables;
+            lootEntriesGrid.AutoGenerateColumns = false;
+            lootEntriesGrid.DataSource = new BindingList<LootEntry>();
+
+            lootEntriesGrid.CellValueChanged += (_, _) => UpdateLootChart();
+            lootEntriesGrid.CurrentCellDirtyStateChanged += (_, _) =>
+            {
+                if (lootEntriesGrid.IsCurrentCellDirty)
+                {
+                    lootEntriesGrid.CommitEdit(DataGridViewDataErrorContexts.Commit);
+                }
+            };
+            lootEntriesGrid.SelectionChanged += (_, _) => UpdateLootChart();
+            lootEntriesGrid.RowsRemoved += (_, _) => UpdateLootChart();
+            lootEntriesGrid.RowsAdded += (_, _) => UpdateLootChart();
+
+            lootKillCountSetter.ValueChanged += (_, _) => UpdateLootChart();
+
+            lootTableIdInput.ValueChanged += (_, _) =>
+            {
+                if (selectedLootTable is null)
+                {
+                    return;
+                }
+
+                int requestedId = (int)lootTableIdInput.Value;
+                if (requestedId == selectedLootTable.Id)
+                {
+                    return;
+                }
+
+                if (LootManager.ContainsId(requestedId))
+                {
+                    MessageBox.Show($"Loot table id {requestedId} already exists.", "Duplicate Id", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    lootTableIdInput.Value = selectedLootTable.Id;
+                    return;
+                }
+
+                selectedLootTable.Id = requestedId;
+            };
+
+            lootTableNameInput.TextChanged += (_, _) =>
+            {
+                if (selectedLootTable is null)
+                {
+                    return;
+                }
+
+                selectedLootTable.Name = lootTableNameInput.Text;
+            };
+
+            lootAddTableButton.Click += (_, _) =>
+            {
+                int id = (int)lootTableIdInput.Value;
+                if (LootManager.ContainsId(id))
+                {
+                    MessageBox.Show($"Loot table id {id} already exists.", "Duplicate Id", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                LootTable table = LootManager.CreateLootTable(id, lootTableNameInput.Text);
+                lootTableListBox.SelectedItem = table;
+            };
+
+            lootRemoveTableButton.Click += (_, _) =>
+            {
+                if (selectedLootTable is null)
+                {
+                    return;
+                }
+
+                LootManager.Remove(selectedLootTable);
+                selectedLootTable = null;
+                lootEntriesGrid.DataSource = new BindingList<LootEntry>();
+                lootTableNameInput.Clear();
+                lootTableIdInput.Value = 0;
+                UpdateLootChart();
+            };
+
+            lootTableListBox.SelectedIndexChanged += (_, _) =>
+            {
+                if (lootTableListBox.SelectedItem is LootTable table)
+                {
+                    SelectLootTable(table);
+                }
+                else
+                {
+                    selectedLootTable = null;
+                    lootEntriesGrid.DataSource = new BindingList<LootEntry>();
+                }
+
+                UpdateLootChart();
+            };
+
+            lootEntriesGrid.DataError += (_, args) =>
+            {
+                MessageBox.Show("Invalid value entered. Please use numeric values for the item id and drop chance (0-1).", "Invalid value", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                args.Cancel = true;
+            };
+
+            InitializeLootChart();
+        }
+
+        void SelectLootTable(LootTable table)
+        {
+            if (selectedLootTable == table)
+            {
+                return;
+            }
+
+            selectedLootTable = table;
+            lootTableIdInput.Value = Math.Max(lootTableIdInput.Minimum, Math.Min(lootTableIdInput.Maximum, table.Id));
+            lootTableNameInput.Text = table.Name;
+
+            BindingList<LootEntry> entries = table.Entries;
+            lootEntriesGrid.DataSource = entries;
+        }
+
+        void InitializeLootChart()
+        {
+            lootProbabilityChart.Series.Clear();
+            lootProbabilityChart.ChartAreas.Clear();
+            ChartArea chartArea = new("LootProbabilityArea");
+            chartArea.AxisX.Title = "Number of drops";
+            chartArea.AxisX.Interval = 1;
+            chartArea.AxisX.MajorGrid.LineColor = Color.LightGray;
+            chartArea.AxisY.Title = "Probability (%)";
+            chartArea.AxisY.LabelStyle.Format = "{0:P1}";
+            chartArea.AxisY.MajorGrid.LineColor = Color.LightGray;
+            lootProbabilityChart.ChartAreas.Add(chartArea);
+
+            lootProbabilityChart.Legends.Clear();
+            lootProbabilityChart.Titles.Clear();
+            lootProbabilityChart.Titles.Add("Drop probability distribution");
+        }
+
+        LootEntry? SelectedLootEntry
+        {
+            get
+            {
+                if (lootEntriesGrid.CurrentRow?.DataBoundItem is LootEntry entry)
+                {
+                    return entry;
+                }
+
+                return null;
+            }
+        }
+
+        void UpdateLootChart()
+        {
+            lootProbabilityChart.Series.Clear();
+
+            LootEntry? entry = SelectedLootEntry;
+            int kills = (int)lootKillCountSetter.Value;
+
+            if (entry is null || selectedLootTable is null)
+            {
+                return;
+            }
+
+            var distribution = LootProbability.CalculateDistribution(entry, kills);
+
+            Series series = new($"Item {entry.ItemId}")
+            {
+                ChartType = SeriesChartType.Column,
+                XValueType = ChartValueType.Int32,
+                YValueType = ChartValueType.Double
+            };
+
+            foreach (var point in distribution)
+            {
+                double percentage = point.Probability;
+                series.Points.AddXY(point.Drops, percentage);
+            }
+
+            lootProbabilityChart.Series.Add(series);
+            lootProbabilityChart.ChartAreas[0].RecalculateAxesScale();
         }
     }
 }

--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="System.Windows.Forms.DataVisualization" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add loot table domain classes for managing entries and probability calculations
- extend the main window with a Loot tab to configure tables, drop chances, and preview drop distributions
- include a chart reference for visualizing probability distributions

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de8c38e94c8331b6296bc767870942