### PR TITLE
Add sprite editor with painting tools

### DIFF
--- a/SPHMMaker/MainForm.Designer.cs
+++ b/SPHMMaker/MainForm.Designer.cs
@@ -1048,7 +1048,7 @@ namespace SPHMMaker
             // 
             // menuStrip1
             // 
-            menuStrip1.Items.AddRange(new ToolStripItem[] { fileToolStripMenuItem, helpToolStripMenuItem });
+            menuStrip1.Items.AddRange(new ToolStripItem[] { fileToolStripMenuItem, toolsToolStripMenuItem, helpToolStripMenuItem });
             menuStrip1.Location = new Point(0, 0);
             menuStrip1.Name = "menuStrip1";
             menuStrip1.Size = new Size(968, 24);
@@ -1082,6 +1082,20 @@ namespace SPHMMaker
             exitToolStripMenuItem.Name = "exitToolStripMenuItem";
             exitToolStripMenuItem.Size = new Size(190, 22);
             exitToolStripMenuItem.Text = "Exit";
+            //
+            // toolsToolStripMenuItem
+            //
+            toolsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { spriteEditorToolStripMenuItem });
+            toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
+            toolsToolStripMenuItem.Size = new Size(46, 20);
+            toolsToolStripMenuItem.Text = "Tools";
+            //
+            // spriteEditorToolStripMenuItem
+            //
+            spriteEditorToolStripMenuItem.Name = "spriteEditorToolStripMenuItem";
+            spriteEditorToolStripMenuItem.Size = new Size(138, 22);
+            spriteEditorToolStripMenuItem.Text = "Sprite Editor";
+            spriteEditorToolStripMenuItem.Click += spriteEditorToolStripMenuItem_Click;
             //
             // helpToolStripMenuItem
             //
@@ -1192,6 +1206,8 @@ namespace SPHMMaker
         private ToolStripMenuItem saveDatapackToolStripMenuItem;
         private ToolStripMenuItem loadDatapackToolStripMenuItem;
         private ToolStripMenuItem exitToolStripMenuItem;
+        private ToolStripMenuItem toolsToolStripMenuItem;
+        private ToolStripMenuItem spriteEditorToolStripMenuItem;
         private ToolStripMenuItem helpToolStripMenuItem;
         private ToolStripMenuItem fileDownloadInstructionsToolStripMenuItem;
         private Button EditItemButton;

--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -12,6 +12,7 @@ namespace SPHMMaker
         static extern bool AllocConsole();
 
         int editingItem = -1;
+        SpriteEditorForm? spriteEditorForm;
 
 
         public MainForm()
@@ -125,9 +126,28 @@ namespace SPHMMaker
                 "1. Hover the message that contains the attachment and select the download icon." + Environment.NewLine +
                 "2. Pick a destination on your computer when the save dialog appears." + Environment.NewLine +
                 "3. After the download finishes, open the saved file from the chosen folder." + Environment.NewLine +
-                "4. If the download is a compressed archive (.zip), extract it before importing it into the game.";
+                "4. If the download is a compressed archive (.zip), extract it before importing it into the game." + Environment.NewLine +
+                "5. You can edit downloaded sprites using Tools > Sprite Editor.";
 
             MessageBox.Show(instructions, "File Download Instructions", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        private void spriteEditorToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (spriteEditorForm == null || spriteEditorForm.IsDisposed)
+            {
+                spriteEditorForm = new SpriteEditorForm();
+                spriteEditorForm.Show(this);
+            }
+            else
+            {
+                if (spriteEditorForm.WindowState == FormWindowState.Minimized)
+                {
+                    spriteEditorForm.WindowState = FormWindowState.Normal;
+                }
+
+                spriteEditorForm.Focus();
+            }
         }
     }
 }

--- a/SPHMMaker/NewCanvasDialog.Designer.cs
+++ b/SPHMMaker/NewCanvasDialog.Designer.cs
@@ -1,0 +1,165 @@
+namespace SPHMMaker
+{
+    partial class NewCanvasDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            widthNumeric = new NumericUpDown();
+            heightNumeric = new NumericUpDown();
+            widthLabel = new Label();
+            heightLabel = new Label();
+            okButton = new Button();
+            cancelButton = new Button();
+            presetLabel = new Label();
+            presetComboBox = new ComboBox();
+            ((System.ComponentModel.ISupportInitialize)widthNumeric).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)heightNumeric).BeginInit();
+            SuspendLayout();
+            // 
+            // widthNumeric
+            // 
+            widthNumeric.Location = new Point(94, 16);
+            widthNumeric.Maximum = new decimal(new int[] { 4096, 0, 0, 0 });
+            widthNumeric.Minimum = new decimal(new int[] { 4, 0, 0, 0 });
+            widthNumeric.Name = "widthNumeric";
+            widthNumeric.Size = new Size(120, 23);
+            widthNumeric.TabIndex = 0;
+            widthNumeric.Value = new decimal(new int[] { 256, 0, 0, 0 });
+            widthNumeric.ValueChanged += widthNumeric_ValueChanged;
+            // 
+            // heightNumeric
+            // 
+            heightNumeric.Location = new Point(94, 54);
+            heightNumeric.Maximum = new decimal(new int[] { 4096, 0, 0, 0 });
+            heightNumeric.Minimum = new decimal(new int[] { 4, 0, 0, 0 });
+            heightNumeric.Name = "heightNumeric";
+            heightNumeric.Size = new Size(120, 23);
+            heightNumeric.TabIndex = 1;
+            heightNumeric.Value = new decimal(new int[] { 256, 0, 0, 0 });
+            heightNumeric.ValueChanged += heightNumeric_ValueChanged;
+            // 
+            // widthLabel
+            // 
+            widthLabel.AutoSize = true;
+            widthLabel.Location = new Point(12, 18);
+            widthLabel.Name = "widthLabel";
+            widthLabel.Size = new Size(39, 15);
+            widthLabel.TabIndex = 2;
+            widthLabel.Text = "Width";
+            // 
+            // heightLabel
+            // 
+            heightLabel.AutoSize = true;
+            heightLabel.Location = new Point(12, 56);
+            heightLabel.Name = "heightLabel";
+            heightLabel.Size = new Size(43, 15);
+            heightLabel.TabIndex = 3;
+            heightLabel.Text = "Height";
+            // 
+            // okButton
+            // 
+            okButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            okButton.DialogResult = DialogResult.OK;
+            okButton.Location = new Point(58, 137);
+            okButton.Name = "okButton";
+            okButton.Size = new Size(75, 27);
+            okButton.TabIndex = 3;
+            okButton.Text = "Create";
+            okButton.UseVisualStyleBackColor = true;
+            okButton.Click += okButton_Click;
+            // 
+            // cancelButton
+            // 
+            cancelButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            cancelButton.DialogResult = DialogResult.Cancel;
+            cancelButton.Location = new Point(139, 137);
+            cancelButton.Name = "cancelButton";
+            cancelButton.Size = new Size(75, 27);
+            cancelButton.TabIndex = 4;
+            cancelButton.Text = "Cancel";
+            cancelButton.UseVisualStyleBackColor = true;
+            // 
+            // presetLabel
+            // 
+            presetLabel.AutoSize = true;
+            presetLabel.Location = new Point(12, 94);
+            presetLabel.Name = "presetLabel";
+            presetLabel.Size = new Size(38, 15);
+            presetLabel.TabIndex = 6;
+            presetLabel.Text = "Preset";
+            // 
+            // presetComboBox
+            // 
+            presetComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            presetComboBox.FormattingEnabled = true;
+            presetComboBox.Items.AddRange(new object[] { "32 x 32", "64 x 64", "128 x 128", "256 x 256", "512 x 512", "1024 x 1024" });
+            presetComboBox.Location = new Point(94, 91);
+            presetComboBox.Name = "presetComboBox";
+            presetComboBox.Size = new Size(120, 23);
+            presetComboBox.TabIndex = 2;
+            presetComboBox.SelectedIndexChanged += presetComboBox_SelectedIndexChanged;
+            // 
+            // NewCanvasDialog
+            // 
+            AcceptButton = okButton;
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            CancelButton = cancelButton;
+            ClientSize = new Size(226, 176);
+            Controls.Add(presetComboBox);
+            Controls.Add(presetLabel);
+            Controls.Add(cancelButton);
+            Controls.Add(okButton);
+            Controls.Add(heightLabel);
+            Controls.Add(widthLabel);
+            Controls.Add(heightNumeric);
+            Controls.Add(widthNumeric);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "NewCanvasDialog";
+            ShowInTaskbar = false;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "New Canvas";
+            ((System.ComponentModel.ISupportInitialize)widthNumeric).EndInit();
+            ((System.ComponentModel.ISupportInitialize)heightNumeric).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private NumericUpDown widthNumeric;
+        private NumericUpDown heightNumeric;
+        private Label widthLabel;
+        private Label heightLabel;
+        private Button okButton;
+        private Button cancelButton;
+        private Label presetLabel;
+        private ComboBox presetComboBox;
+    }
+}

--- a/SPHMMaker/NewCanvasDialog.cs
+++ b/SPHMMaker/NewCanvasDialog.cs
@@ -1,0 +1,58 @@
+using System.Windows.Forms;
+
+namespace SPHMMaker
+{
+    public partial class NewCanvasDialog : Form
+    {
+        public int CanvasWidth => (int)widthNumeric.Value;
+        public int CanvasHeight => (int)heightNumeric.Value;
+
+        public NewCanvasDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void okButton_Click(object? sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void presetComboBox_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (presetComboBox.SelectedItem is string preset)
+            {
+                string[] parts = preset.Split('x', 'X');
+                if (parts.Length == 2 && int.TryParse(parts[0].Trim(), out int width) && int.TryParse(parts[1].Trim(), out int height))
+                {
+                    widthNumeric.Value = Math.Clamp(width, (int)widthNumeric.Minimum, (int)widthNumeric.Maximum);
+                    heightNumeric.Value = Math.Clamp(height, (int)heightNumeric.Minimum, (int)heightNumeric.Maximum);
+                }
+            }
+        }
+
+        private void widthNumeric_ValueChanged(object? sender, EventArgs e)
+        {
+            ValidateAspectPreset();
+        }
+
+        private void heightNumeric_ValueChanged(object? sender, EventArgs e)
+        {
+            ValidateAspectPreset();
+        }
+
+        private void ValidateAspectPreset()
+        {
+            string comboValue = $"{CanvasWidth} x {CanvasHeight}";
+            int index = presetComboBox.FindStringExact(comboValue);
+            if (index >= 0)
+            {
+                presetComboBox.SelectedIndex = index;
+            }
+            else
+            {
+                presetComboBox.SelectedIndex = -1;
+            }
+        }
+    }
+}

--- a/SPHMMaker/NewCanvasDialog.resx
+++ b/SPHMMaker/NewCanvasDialog.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -12,4 +12,19 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="SpriteEditorForm.Designer.cs">
+      <DependentUpon>SpriteEditorForm.cs</DependentUpon>
+    </Compile>
+    <Compile Update="NewCanvasDialog.Designer.cs">
+      <DependentUpon>NewCanvasDialog.cs</DependentUpon>
+    </Compile>
+    <EmbeddedResource Update="SpriteEditorForm.resx">
+      <DependentUpon>SpriteEditorForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="NewCanvasDialog.resx">
+      <DependentUpon>NewCanvasDialog.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/SPHMMaker/SpriteEditorForm.Designer.cs
+++ b/SPHMMaker/SpriteEditorForm.Designer.cs
@@ -1,0 +1,566 @@
+namespace SPHMMaker
+{
+    partial class SpriteEditorForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            menuStrip = new MenuStrip();
+            fileToolStripMenuItem = new ToolStripMenuItem();
+            newCanvasToolStripMenuItem = new ToolStripMenuItem();
+            openToolStripMenuItem = new ToolStripMenuItem();
+            saveToolStripMenuItem = new ToolStripMenuItem();
+            saveAsToolStripMenuItem = new ToolStripMenuItem();
+            editToolStripMenuItem = new ToolStripMenuItem();
+            undoToolStripMenuItem = new ToolStripMenuItem();
+            redoToolStripMenuItem = new ToolStripMenuItem();
+            clearCanvasToolStripMenuItem = new ToolStripMenuItem();
+            viewToolStripMenuItem = new ToolStripMenuItem();
+            zoomInToolStripMenuItem = new ToolStripMenuItem();
+            zoomOutToolStripMenuItem = new ToolStripMenuItem();
+            resetZoomToolStripMenuItem = new ToolStripMenuItem();
+            toggleGridToolStripMenuItem = new ToolStripMenuItem();
+            colorsToolStripMenuItem = new ToolStripMenuItem();
+            swapColorsToolStripMenuItem = new ToolStripMenuItem();
+            choosePrimaryColorToolStripMenuItem = new ToolStripMenuItem();
+            chooseSecondaryColorToolStripMenuItem = new ToolStripMenuItem();
+            toolStrip = new ToolStrip();
+            pencilToolStripButton = new ToolStripButton();
+            eraserToolStripButton = new ToolStripButton();
+            fillToolStripButton = new ToolStripButton();
+            colorPickerToolStripButton = new ToolStripButton();
+            lineToolStripButton = new ToolStripButton();
+            rectangleToolStripButton = new ToolStripButton();
+            ellipseToolStripButton = new ToolStripButton();
+            toolStripSeparator1 = new ToolStripSeparator();
+            brushSizeLabel = new ToolStripLabel();
+            brushSizeComboBox = new ToolStripComboBox();
+            toolStripSeparator2 = new ToolStripSeparator();
+            fillShapeToolStripButton = new ToolStripButton();
+            toolStripSeparator3 = new ToolStripSeparator();
+            zoomDropDownButton = new ToolStripDropDownButton();
+            zoom25ToolStripMenuItem = new ToolStripMenuItem();
+            zoom50ToolStripMenuItem = new ToolStripMenuItem();
+            zoom100ToolStripMenuItem = new ToolStripMenuItem();
+            zoom200ToolStripMenuItem = new ToolStripMenuItem();
+            zoom400ToolStripMenuItem = new ToolStripMenuItem();
+            colorPalettePanel = new FlowLayoutPanel();
+            colorToolTip = new ToolTip(components);
+            canvasContainer = new Panel();
+            canvasView = new PictureBox();
+            statusStrip = new StatusStrip();
+            statusPositionLabel = new ToolStripStatusLabel();
+            statusToolLabel = new ToolStripStatusLabel();
+            statusZoomLabel = new ToolStripStatusLabel();
+            primaryColorPanel = new Panel();
+            secondaryColorPanel = new Panel();
+            primaryColorLabel = new Label();
+            secondaryColorLabel = new Label();
+            colorPreviewContainer = new TableLayoutPanel();
+            menuStrip.SuspendLayout();
+            toolStrip.SuspendLayout();
+            canvasContainer.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)canvasView).BeginInit();
+            statusStrip.SuspendLayout();
+            colorPreviewContainer.SuspendLayout();
+            SuspendLayout();
+            // 
+            // menuStrip
+            // 
+            menuStrip.Items.AddRange(new ToolStripItem[] { fileToolStripMenuItem, editToolStripMenuItem, viewToolStripMenuItem, colorsToolStripMenuItem });
+            menuStrip.Location = new Point(0, 0);
+            menuStrip.Name = "menuStrip";
+            menuStrip.Size = new Size(1184, 24);
+            menuStrip.TabIndex = 0;
+            menuStrip.Text = "menuStrip1";
+            // 
+            // fileToolStripMenuItem
+            // 
+            fileToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { newCanvasToolStripMenuItem, openToolStripMenuItem, saveToolStripMenuItem, saveAsToolStripMenuItem });
+            fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            fileToolStripMenuItem.Size = new Size(37, 20);
+            fileToolStripMenuItem.Text = "File";
+            // 
+            // newCanvasToolStripMenuItem
+            // 
+            newCanvasToolStripMenuItem.Name = "newCanvasToolStripMenuItem";
+            newCanvasToolStripMenuItem.Size = new Size(180, 22);
+            newCanvasToolStripMenuItem.Text = "New";
+            newCanvasToolStripMenuItem.Click += newCanvasToolStripMenuItem_Click;
+            // 
+            // openToolStripMenuItem
+            // 
+            openToolStripMenuItem.Name = "openToolStripMenuItem";
+            openToolStripMenuItem.Size = new Size(180, 22);
+            openToolStripMenuItem.Text = "Open...";
+            openToolStripMenuItem.Click += openToolStripMenuItem_Click;
+            // 
+            // saveToolStripMenuItem
+            // 
+            saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            saveToolStripMenuItem.Size = new Size(180, 22);
+            saveToolStripMenuItem.Text = "Save";
+            saveToolStripMenuItem.Click += saveToolStripMenuItem_Click;
+            // 
+            // saveAsToolStripMenuItem
+            // 
+            saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            saveAsToolStripMenuItem.Size = new Size(180, 22);
+            saveAsToolStripMenuItem.Text = "Save As...";
+            saveAsToolStripMenuItem.Click += saveAsToolStripMenuItem_Click;
+            // 
+            // editToolStripMenuItem
+            // 
+            editToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { undoToolStripMenuItem, redoToolStripMenuItem, clearCanvasToolStripMenuItem });
+            editToolStripMenuItem.Name = "editToolStripMenuItem";
+            editToolStripMenuItem.Size = new Size(39, 20);
+            editToolStripMenuItem.Text = "Edit";
+            // 
+            // undoToolStripMenuItem
+            // 
+            undoToolStripMenuItem.Name = "undoToolStripMenuItem";
+            undoToolStripMenuItem.Size = new Size(135, 22);
+            undoToolStripMenuItem.Text = "Undo";
+            undoToolStripMenuItem.Click += undoToolStripMenuItem_Click;
+            // 
+            // redoToolStripMenuItem
+            // 
+            redoToolStripMenuItem.Name = "redoToolStripMenuItem";
+            redoToolStripMenuItem.Size = new Size(135, 22);
+            redoToolStripMenuItem.Text = "Redo";
+            redoToolStripMenuItem.Click += redoToolStripMenuItem_Click;
+            // 
+            // clearCanvasToolStripMenuItem
+            // 
+            clearCanvasToolStripMenuItem.Name = "clearCanvasToolStripMenuItem";
+            clearCanvasToolStripMenuItem.Size = new Size(135, 22);
+            clearCanvasToolStripMenuItem.Text = "Clear";
+            clearCanvasToolStripMenuItem.Click += clearCanvasToolStripMenuItem_Click;
+            // 
+            // viewToolStripMenuItem
+            // 
+            viewToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { zoomInToolStripMenuItem, zoomOutToolStripMenuItem, resetZoomToolStripMenuItem, toggleGridToolStripMenuItem });
+            viewToolStripMenuItem.Name = "viewToolStripMenuItem";
+            viewToolStripMenuItem.Size = new Size(44, 20);
+            viewToolStripMenuItem.Text = "View";
+            // 
+            // zoomInToolStripMenuItem
+            // 
+            zoomInToolStripMenuItem.Name = "zoomInToolStripMenuItem";
+            zoomInToolStripMenuItem.Size = new Size(134, 22);
+            zoomInToolStripMenuItem.Text = "Zoom In";
+            zoomInToolStripMenuItem.Click += zoomInToolStripMenuItem_Click;
+            // 
+            // zoomOutToolStripMenuItem
+            // 
+            zoomOutToolStripMenuItem.Name = "zoomOutToolStripMenuItem";
+            zoomOutToolStripMenuItem.Size = new Size(134, 22);
+            zoomOutToolStripMenuItem.Text = "Zoom Out";
+            zoomOutToolStripMenuItem.Click += zoomOutToolStripMenuItem_Click;
+            // 
+            // resetZoomToolStripMenuItem
+            // 
+            resetZoomToolStripMenuItem.Name = "resetZoomToolStripMenuItem";
+            resetZoomToolStripMenuItem.Size = new Size(134, 22);
+            resetZoomToolStripMenuItem.Text = "Reset";
+            resetZoomToolStripMenuItem.Click += resetZoomToolStripMenuItem_Click;
+            // 
+            // toggleGridToolStripMenuItem
+            // 
+            toggleGridToolStripMenuItem.Name = "toggleGridToolStripMenuItem";
+            toggleGridToolStripMenuItem.Size = new Size(134, 22);
+            toggleGridToolStripMenuItem.Text = "Toggle Grid";
+            toggleGridToolStripMenuItem.Click += toggleGridToolStripMenuItem_Click;
+            // 
+            // colorsToolStripMenuItem
+            // 
+            colorsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { swapColorsToolStripMenuItem, choosePrimaryColorToolStripMenuItem, chooseSecondaryColorToolStripMenuItem });
+            colorsToolStripMenuItem.Name = "colorsToolStripMenuItem";
+            colorsToolStripMenuItem.Size = new Size(53, 20);
+            colorsToolStripMenuItem.Text = "Colors";
+            // 
+            // swapColorsToolStripMenuItem
+            // 
+            swapColorsToolStripMenuItem.Name = "swapColorsToolStripMenuItem";
+            swapColorsToolStripMenuItem.Size = new Size(190, 22);
+            swapColorsToolStripMenuItem.Text = "Swap";
+            swapColorsToolStripMenuItem.Click += swapColorsToolStripMenuItem_Click;
+            // 
+            // choosePrimaryColorToolStripMenuItem
+            // 
+            choosePrimaryColorToolStripMenuItem.Name = "choosePrimaryColorToolStripMenuItem";
+            choosePrimaryColorToolStripMenuItem.Size = new Size(190, 22);
+            choosePrimaryColorToolStripMenuItem.Text = "Choose Primary...";
+            choosePrimaryColorToolStripMenuItem.Click += choosePrimaryColorToolStripMenuItem_Click;
+            // 
+            // chooseSecondaryColorToolStripMenuItem
+            // 
+            chooseSecondaryColorToolStripMenuItem.Name = "chooseSecondaryColorToolStripMenuItem";
+            chooseSecondaryColorToolStripMenuItem.Size = new Size(190, 22);
+            chooseSecondaryColorToolStripMenuItem.Text = "Choose Secondary...";
+            chooseSecondaryColorToolStripMenuItem.Click += chooseSecondaryColorToolStripMenuItem_Click;
+            // 
+            // toolStrip
+            // 
+            toolStrip.GripStyle = ToolStripGripStyle.Hidden;
+            toolStrip.Items.AddRange(new ToolStripItem[] { pencilToolStripButton, eraserToolStripButton, fillToolStripButton, colorPickerToolStripButton, lineToolStripButton, rectangleToolStripButton, ellipseToolStripButton, toolStripSeparator1, brushSizeLabel, brushSizeComboBox, toolStripSeparator2, fillShapeToolStripButton, toolStripSeparator3, zoomDropDownButton });
+            toolStrip.Location = new Point(0, 24);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new Padding(5, 0, 1, 0);
+            toolStrip.Size = new Size(1184, 25);
+            toolStrip.TabIndex = 1;
+            toolStrip.Text = "toolStrip1";
+            // 
+            // pencilToolStripButton
+            // 
+            pencilToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            pencilToolStripButton.Name = "pencilToolStripButton";
+            pencilToolStripButton.Size = new Size(43, 22);
+            pencilToolStripButton.Text = "Pencil";
+            pencilToolStripButton.Click += toolButton_Click;
+            // 
+            // eraserToolStripButton
+            // 
+            eraserToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            eraserToolStripButton.Name = "eraserToolStripButton";
+            eraserToolStripButton.Size = new Size(44, 22);
+            eraserToolStripButton.Text = "Eraser";
+            eraserToolStripButton.Click += toolButton_Click;
+            // 
+            // fillToolStripButton
+            // 
+            fillToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            fillToolStripButton.Name = "fillToolStripButton";
+            fillToolStripButton.Size = new Size(29, 22);
+            fillToolStripButton.Text = "Fill";
+            fillToolStripButton.Click += toolButton_Click;
+            // 
+            // colorPickerToolStripButton
+            // 
+            colorPickerToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            colorPickerToolStripButton.Name = "colorPickerToolStripButton";
+            colorPickerToolStripButton.Size = new Size(76, 22);
+            colorPickerToolStripButton.Text = "Color Picker";
+            colorPickerToolStripButton.Click += toolButton_Click;
+            // 
+            // lineToolStripButton
+            // 
+            lineToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            lineToolStripButton.Name = "lineToolStripButton";
+            lineToolStripButton.Size = new Size(34, 22);
+            lineToolStripButton.Text = "Line";
+            lineToolStripButton.Click += toolButton_Click;
+            // 
+            // rectangleToolStripButton
+            // 
+            rectangleToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            rectangleToolStripButton.Name = "rectangleToolStripButton";
+            rectangleToolStripButton.Size = new Size(63, 22);
+            rectangleToolStripButton.Text = "Rectangle";
+            rectangleToolStripButton.Click += toolButton_Click;
+            // 
+            // ellipseToolStripButton
+            // 
+            ellipseToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            ellipseToolStripButton.Name = "ellipseToolStripButton";
+            ellipseToolStripButton.Size = new Size(45, 22);
+            ellipseToolStripButton.Text = "Ellipse";
+            ellipseToolStripButton.Click += toolButton_Click;
+            // 
+            // brushSizeLabel
+            // 
+            brushSizeLabel.Name = "brushSizeLabel";
+            brushSizeLabel.Size = new Size(65, 22);
+            brushSizeLabel.Text = "Brush Size";
+            // 
+            // brushSizeComboBox
+            // 
+            brushSizeComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            brushSizeComboBox.Name = "brushSizeComboBox";
+            brushSizeComboBox.Size = new Size(75, 25);
+            brushSizeComboBox.SelectedIndexChanged += brushSizeComboBox_SelectedIndexChanged;
+            // 
+            // fillShapeToolStripButton
+            // 
+            fillShapeToolStripButton.CheckOnClick = true;
+            fillShapeToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            fillShapeToolStripButton.Name = "fillShapeToolStripButton";
+            fillShapeToolStripButton.Size = new Size(60, 22);
+            fillShapeToolStripButton.Text = "Fill Shape";
+            fillShapeToolStripButton.ToolTipText = "Toggle between filled and outlined shapes";
+            fillShapeToolStripButton.CheckedChanged += fillShapeToolStripButton_CheckedChanged;
+            // 
+            // zoomDropDownButton
+            // 
+            zoomDropDownButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            zoomDropDownButton.DropDownItems.AddRange(new ToolStripItem[] { zoom25ToolStripMenuItem, zoom50ToolStripMenuItem, zoom100ToolStripMenuItem, zoom200ToolStripMenuItem, zoom400ToolStripMenuItem });
+            zoomDropDownButton.Name = "zoomDropDownButton";
+            zoomDropDownButton.Size = new Size(50, 22);
+            zoomDropDownButton.Text = "Zoom";
+            // 
+            // zoom25ToolStripMenuItem
+            // 
+            zoom25ToolStripMenuItem.Name = "zoom25ToolStripMenuItem";
+            zoom25ToolStripMenuItem.Size = new Size(102, 22);
+            zoom25ToolStripMenuItem.Text = "25%";
+            zoom25ToolStripMenuItem.Click += zoomPreset_Click;
+            // 
+            // zoom50ToolStripMenuItem
+            // 
+            zoom50ToolStripMenuItem.Name = "zoom50ToolStripMenuItem";
+            zoom50ToolStripMenuItem.Size = new Size(102, 22);
+            zoom50ToolStripMenuItem.Text = "50%";
+            zoom50ToolStripMenuItem.Click += zoomPreset_Click;
+            // 
+            // zoom100ToolStripMenuItem
+            // 
+            zoom100ToolStripMenuItem.Name = "zoom100ToolStripMenuItem";
+            zoom100ToolStripMenuItem.Size = new Size(102, 22);
+            zoom100ToolStripMenuItem.Text = "100%";
+            zoom100ToolStripMenuItem.Click += zoomPreset_Click;
+            // 
+            // zoom200ToolStripMenuItem
+            // 
+            zoom200ToolStripMenuItem.Name = "zoom200ToolStripMenuItem";
+            zoom200ToolStripMenuItem.Size = new Size(102, 22);
+            zoom200ToolStripMenuItem.Text = "200%";
+            zoom200ToolStripMenuItem.Click += zoomPreset_Click;
+            // 
+            // zoom400ToolStripMenuItem
+            // 
+            zoom400ToolStripMenuItem.Name = "zoom400ToolStripMenuItem";
+            zoom400ToolStripMenuItem.Size = new Size(102, 22);
+            zoom400ToolStripMenuItem.Text = "400%";
+            zoom400ToolStripMenuItem.Click += zoomPreset_Click;
+            // 
+            // colorPalettePanel
+            // 
+            colorPalettePanel.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            colorPalettePanel.AutoScroll = true;
+            colorPalettePanel.Location = new Point(964, 52);
+            colorPalettePanel.Name = "colorPalettePanel";
+            colorPalettePanel.Padding = new Padding(6);
+            colorPalettePanel.Size = new Size(208, 264);
+            colorPalettePanel.TabIndex = 3;
+            // 
+            // canvasContainer
+            // 
+            canvasContainer.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            canvasContainer.AutoScroll = true;
+            canvasContainer.BackColor = Color.DarkGray;
+            canvasContainer.Controls.Add(canvasView);
+            canvasContainer.Location = new Point(12, 52);
+            canvasContainer.Name = "canvasContainer";
+            canvasContainer.Size = new Size(946, 657);
+            canvasContainer.TabIndex = 2;
+            // 
+            // canvasView
+            // 
+            canvasView.BackColor = Color.Transparent;
+            canvasView.Location = new Point(0, 0);
+            canvasView.Name = "canvasView";
+            canvasView.Size = new Size(512, 512);
+            canvasView.TabIndex = 0;
+            canvasView.TabStop = false;
+            canvasView.Paint += canvasView_Paint;
+            canvasView.MouseDown += canvasView_MouseDown;
+            canvasView.MouseMove += canvasView_MouseMove;
+            canvasView.MouseUp += canvasView_MouseUp;
+            // 
+            // statusStrip
+            // 
+            statusStrip.Items.AddRange(new ToolStripItem[] { statusPositionLabel, statusToolLabel, statusZoomLabel });
+            statusStrip.Location = new Point(0, 732);
+            statusStrip.Name = "statusStrip";
+            statusStrip.Size = new Size(1184, 22);
+            statusStrip.TabIndex = 4;
+            statusStrip.Text = "statusStrip1";
+            // 
+            // statusPositionLabel
+            // 
+            statusPositionLabel.Name = "statusPositionLabel";
+            statusPositionLabel.Size = new Size(25, 17);
+            statusPositionLabel.Text = "X:0";
+            // 
+            // statusToolLabel
+            // 
+            statusToolLabel.Name = "statusToolLabel";
+            statusToolLabel.Size = new Size(60, 17);
+            statusToolLabel.Text = "Tool: N/A";
+            // 
+            // statusZoomLabel
+            // 
+            statusZoomLabel.Name = "statusZoomLabel";
+            statusZoomLabel.Size = new Size(67, 17);
+            statusZoomLabel.Text = "Zoom: 100%";
+            // 
+            // primaryColorPanel
+            // 
+            primaryColorPanel.BorderStyle = BorderStyle.FixedSingle;
+            primaryColorPanel.Dock = DockStyle.Fill;
+            primaryColorPanel.Location = new Point(3, 18);
+            primaryColorPanel.Name = "primaryColorPanel";
+            primaryColorPanel.Size = new Size(94, 64);
+            primaryColorPanel.TabIndex = 5;
+            primaryColorPanel.Click += primaryColorPanel_Click;
+            // 
+            // secondaryColorPanel
+            // 
+            secondaryColorPanel.BorderStyle = BorderStyle.FixedSingle;
+            secondaryColorPanel.Dock = DockStyle.Fill;
+            secondaryColorPanel.Location = new Point(103, 18);
+            secondaryColorPanel.Name = "secondaryColorPanel";
+            secondaryColorPanel.Size = new Size(94, 64);
+            secondaryColorPanel.TabIndex = 6;
+            secondaryColorPanel.Click += secondaryColorPanel_Click;
+            // 
+            // primaryColorLabel
+            // 
+            primaryColorLabel.AutoSize = true;
+            primaryColorLabel.Dock = DockStyle.Fill;
+            primaryColorLabel.Location = new Point(3, 0);
+            primaryColorLabel.Name = "primaryColorLabel";
+            primaryColorLabel.Size = new Size(94, 15);
+            primaryColorLabel.TabIndex = 7;
+            primaryColorLabel.Text = "Primary";
+            primaryColorLabel.TextAlign = ContentAlignment.MiddleCenter;
+            // 
+            // secondaryColorLabel
+            // 
+            secondaryColorLabel.AutoSize = true;
+            secondaryColorLabel.Dock = DockStyle.Fill;
+            secondaryColorLabel.Location = new Point(103, 0);
+            secondaryColorLabel.Name = "secondaryColorLabel";
+            secondaryColorLabel.Size = new Size(94, 15);
+            secondaryColorLabel.TabIndex = 8;
+            secondaryColorLabel.Text = "Secondary";
+            secondaryColorLabel.TextAlign = ContentAlignment.MiddleCenter;
+            // 
+            // colorPreviewContainer
+            // 
+            colorPreviewContainer.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            colorPreviewContainer.ColumnCount = 2;
+            colorPreviewContainer.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            colorPreviewContainer.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            colorPreviewContainer.Controls.Add(primaryColorLabel, 0, 0);
+            colorPreviewContainer.Controls.Add(secondaryColorLabel, 1, 0);
+            colorPreviewContainer.Controls.Add(primaryColorPanel, 0, 1);
+            colorPreviewContainer.Controls.Add(secondaryColorPanel, 1, 1);
+            colorPreviewContainer.Location = new Point(964, 322);
+            colorPreviewContainer.Name = "colorPreviewContainer";
+            colorPreviewContainer.RowCount = 2;
+            colorPreviewContainer.RowStyles.Add(new RowStyle(SizeType.Absolute, 18F));
+            colorPreviewContainer.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            colorPreviewContainer.Size = new Size(200, 85);
+            colorPreviewContainer.TabIndex = 5;
+            // 
+            // SpriteEditorForm
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(1184, 754);
+            Controls.Add(colorPreviewContainer);
+            Controls.Add(statusStrip);
+            Controls.Add(colorPalettePanel);
+            Controls.Add(canvasContainer);
+            Controls.Add(toolStrip);
+            Controls.Add(menuStrip);
+            MainMenuStrip = menuStrip;
+            MinimumSize = new Size(1000, 600);
+            Name = "SpriteEditorForm";
+            Text = "Sprite Editor";
+            FormClosing += SpriteEditorForm_FormClosing;
+            menuStrip.ResumeLayout(false);
+            menuStrip.PerformLayout();
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            canvasContainer.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)canvasView).EndInit();
+            statusStrip.ResumeLayout(false);
+            statusStrip.PerformLayout();
+            colorPreviewContainer.ResumeLayout(false);
+            colorPreviewContainer.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private MenuStrip menuStrip;
+        private ToolStripMenuItem fileToolStripMenuItem;
+        private ToolStripMenuItem newCanvasToolStripMenuItem;
+        private ToolStripMenuItem openToolStripMenuItem;
+        private ToolStripMenuItem saveToolStripMenuItem;
+        private ToolStripMenuItem saveAsToolStripMenuItem;
+        private ToolStripMenuItem editToolStripMenuItem;
+        private ToolStripMenuItem undoToolStripMenuItem;
+        private ToolStripMenuItem redoToolStripMenuItem;
+        private ToolStripMenuItem clearCanvasToolStripMenuItem;
+        private ToolStripMenuItem viewToolStripMenuItem;
+        private ToolStripMenuItem zoomInToolStripMenuItem;
+        private ToolStripMenuItem zoomOutToolStripMenuItem;
+        private ToolStripMenuItem resetZoomToolStripMenuItem;
+        private ToolStripMenuItem toggleGridToolStripMenuItem;
+        private ToolStripMenuItem colorsToolStripMenuItem;
+        private ToolStripMenuItem swapColorsToolStripMenuItem;
+        private ToolStripMenuItem choosePrimaryColorToolStripMenuItem;
+        private ToolStripMenuItem chooseSecondaryColorToolStripMenuItem;
+        private ToolStrip toolStrip;
+        private ToolStripButton pencilToolStripButton;
+        private ToolStripButton eraserToolStripButton;
+        private ToolStripButton fillToolStripButton;
+        private ToolStripButton colorPickerToolStripButton;
+        private ToolStripButton lineToolStripButton;
+        private ToolStripButton rectangleToolStripButton;
+        private ToolStripButton ellipseToolStripButton;
+        private ToolStripSeparator toolStripSeparator1;
+        private ToolStripLabel brushSizeLabel;
+        private ToolStripComboBox brushSizeComboBox;
+        private ToolStripSeparator toolStripSeparator2;
+        private ToolStripButton fillShapeToolStripButton;
+        private ToolStripSeparator toolStripSeparator3;
+        private ToolStripDropDownButton zoomDropDownButton;
+        private ToolStripMenuItem zoom25ToolStripMenuItem;
+        private ToolStripMenuItem zoom50ToolStripMenuItem;
+        private ToolStripMenuItem zoom100ToolStripMenuItem;
+        private ToolStripMenuItem zoom200ToolStripMenuItem;
+        private ToolStripMenuItem zoom400ToolStripMenuItem;
+        private FlowLayoutPanel colorPalettePanel;
+        private ToolTip colorToolTip;
+        private Panel canvasContainer;
+        private PictureBox canvasView;
+        private StatusStrip statusStrip;
+        private ToolStripStatusLabel statusPositionLabel;
+        private ToolStripStatusLabel statusToolLabel;
+        private ToolStripStatusLabel statusZoomLabel;
+        private Panel primaryColorPanel;
+        private Panel secondaryColorPanel;
+        private Label primaryColorLabel;
+        private Label secondaryColorLabel;
+        private TableLayoutPanel colorPreviewContainer;
+    }
+}

--- a/SPHMMaker/SpriteEditorForm.cs
+++ b/SPHMMaker/SpriteEditorForm.cs
@@ -1,0 +1,832 @@
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace SPHMMaker
+{
+    public partial class SpriteEditorForm : Form
+    {
+        private enum ToolType
+        {
+            Pencil,
+            Eraser,
+            Fill,
+            ColorPicker,
+            Line,
+            Rectangle,
+            Ellipse
+        }
+
+        private readonly Dictionary<ToolType, ToolStripButton> toolButtons;
+        private readonly Color[] defaultPalette =
+        [
+            Color.Black, Color.White, Color.Gray, Color.Silver, Color.Maroon, Color.Red, Color.Orange, Color.Yellow,
+            Color.Olive, Color.Green, Color.Teal, Color.Cyan, Color.Blue, Color.Navy, Color.Purple, Color.Magenta,
+            Color.Brown, Color.Gold, Color.Khaki, Color.Lime, Color.Aquamarine, Color.SkyBlue, Color.Indigo,
+            Color.Pink, Color.Beige, Color.Coral, Color.DarkRed, Color.DarkOrange, Color.DarkGreen, Color.DarkSlateBlue,
+            Color.LightGray, Color.LightCoral, Color.LightGreen, Color.LightBlue, Color.WhiteSmoke, Color.Black
+        ];
+
+        private Bitmap canvas;
+        private Bitmap? overlay;
+        private float zoom = 1f;
+        private const int DefaultCanvasSize = 256;
+        private ToolType currentTool = ToolType.Pencil;
+        private Color primaryColor = Color.Black;
+        private Color secondaryColor = Color.White;
+        private int brushSize = 1;
+        private bool fillShape = true;
+        private bool showGrid = true;
+        private bool isDrawing;
+        private Point startPoint;
+        private Point lastPoint;
+        private Color currentStrokeColor = Color.Black;
+        private readonly Stack<Bitmap> undoStack = new();
+        private readonly Stack<Bitmap> redoStack = new();
+        private readonly ColorDialog colorDialog = new();
+        private string? currentFilePath;
+        private bool hasUnsavedChanges;
+
+        public SpriteEditorForm()
+        {
+            InitializeComponent();
+
+            toolButtons = new Dictionary<ToolType, ToolStripButton>
+            {
+                { ToolType.Pencil, pencilToolStripButton },
+                { ToolType.Eraser, eraserToolStripButton },
+                { ToolType.Fill, fillToolStripButton },
+                { ToolType.ColorPicker, colorPickerToolStripButton },
+                { ToolType.Line, lineToolStripButton },
+                { ToolType.Rectangle, rectangleToolStripButton },
+                { ToolType.Ellipse, ellipseToolStripButton }
+            };
+
+            foreach (ToolStripButton button in toolButtons.Values)
+            {
+                button.CheckOnClick = true;
+            }
+
+            brushSizeComboBox.Items.AddRange(new object[] { "1", "2", "3", "4", "5", "8", "12", "16", "24", "32" });
+            brushSizeComboBox.SelectedIndex = 0;
+            fillShapeToolStripButton.Checked = true;
+
+            InitializeCanvas(DefaultCanvasSize, DefaultCanvasSize);
+            PopulatePalette();
+            UpdateToolSelection(ToolType.Pencil);
+            UpdateColorPanels();
+            UpdateStatusLabels(Point.Empty);
+            RefreshCanvas();
+        }
+
+        #region Initialization Helpers
+
+        private void InitializeCanvas(int width, int height)
+        {
+            canvas?.Dispose();
+            canvas = new Bitmap(width, height);
+            using var g = Graphics.FromImage(canvas);
+            g.Clear(Color.Transparent);
+            overlay?.Dispose();
+            overlay = null;
+            ClearStack(undoStack);
+            ClearStack(redoStack);
+            currentFilePath = null;
+            hasUnsavedChanges = false;
+            ResetZoom();
+        }
+
+        private void PopulatePalette()
+        {
+            colorPalettePanel.SuspendLayout();
+            colorPalettePanel.Controls.Clear();
+            foreach (Color color in defaultPalette)
+            {
+                var swatch = new Panel
+                {
+                    BackColor = color,
+                    Width = 32,
+                    Height = 32,
+                    Margin = new Padding(6)
+                };
+                colorToolTip.SetToolTip(swatch, color.Name);
+                swatch.Click += (_, args) =>
+                {
+                    MouseEventArgs? mouse = args as MouseEventArgs;
+                    if (mouse != null && mouse.Button == MouseButtons.Right)
+                    {
+                        secondaryColor = color;
+                    }
+                    else
+                    {
+                        primaryColor = color;
+                    }
+                    UpdateColorPanels();
+                };
+
+                colorPalettePanel.Controls.Add(swatch);
+            }
+            colorPalettePanel.ResumeLayout();
+        }
+
+        private void UpdateColorPanels()
+        {
+            primaryColorPanel.BackColor = primaryColor;
+            secondaryColorPanel.BackColor = secondaryColor;
+        }
+
+        #endregion
+
+        #region Canvas Rendering
+
+        private void RefreshCanvas()
+        {
+            canvasView.Size = new Size((int)(canvas.Width * zoom), (int)(canvas.Height * zoom));
+            canvasView.Invalidate();
+            statusZoomLabel.Text = $"Zoom: {(int)(zoom * 100)}%";
+        }
+
+        private static void DrawCheckerboard(Graphics graphics, Rectangle area, int cellSize)
+        {
+            using SolidBrush light = new(Color.FromArgb(240, 240, 240));
+            using SolidBrush dark = new(Color.FromArgb(200, 200, 200));
+            bool toggle = false;
+            for (int y = area.Top; y < area.Bottom; y += cellSize)
+            {
+                toggle = !toggle;
+                for (int x = area.Left; x < area.Right; x += cellSize)
+                {
+                    Rectangle cell = new(x, y, cellSize, cellSize);
+                    graphics.FillRectangle(toggle ? light : dark, cell);
+                    toggle = !toggle;
+                }
+            }
+        }
+
+        private Bitmap GetCompositeImage()
+        {
+            Bitmap composite = new(canvas.Width, canvas.Height);
+            using Graphics g = Graphics.FromImage(composite);
+            g.SmoothingMode = SmoothingMode.None;
+            g.InterpolationMode = InterpolationMode.NearestNeighbor;
+            DrawCheckerboard(g, new Rectangle(Point.Empty, canvas.Size), 16);
+            g.DrawImage(canvas, Point.Empty);
+            if (overlay != null)
+            {
+                g.DrawImage(overlay, Point.Empty);
+            }
+            return composite;
+        }
+
+        private void canvasView_Paint(object? sender, PaintEventArgs e)
+        {
+            e.Graphics.InterpolationMode = InterpolationMode.NearestNeighbor;
+            e.Graphics.PixelOffsetMode = PixelOffsetMode.Half;
+            e.Graphics.SmoothingMode = SmoothingMode.None;
+
+            using Bitmap composite = GetCompositeImage();
+            e.Graphics.Clear(Color.Gray);
+            e.Graphics.ScaleTransform(zoom, zoom);
+            e.Graphics.DrawImage(composite, 0, 0);
+
+            if (showGrid && zoom >= 4f)
+            {
+                using Pen gridPen = new(Color.FromArgb(120, Color.Black), 0f);
+                for (int x = 0; x <= canvas.Width; x++)
+                {
+                    e.Graphics.DrawLine(gridPen, x, 0, x, canvas.Height);
+                }
+                for (int y = 0; y <= canvas.Height; y++)
+                {
+                    e.Graphics.DrawLine(gridPen, 0, y, canvas.Width, y);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Mouse Handling
+
+        private void canvasView_MouseDown(object? sender, MouseEventArgs e)
+        {
+            if (e.Button != MouseButtons.Left && e.Button != MouseButtons.Right)
+            {
+                return;
+            }
+
+            Point canvasPoint = ScreenToCanvas(e.Location);
+            if (!IsWithinCanvas(canvasPoint))
+            {
+                return;
+            }
+
+            bool modifiesCanvas = currentTool != ToolType.ColorPicker;
+            if (modifiesCanvas)
+            {
+                SaveUndoState();
+                ClearStack(redoStack);
+            }
+
+            isDrawing = true;
+            startPoint = canvasPoint;
+            lastPoint = canvasPoint;
+            currentStrokeColor = GetActiveColor(e.Button);
+
+            if (currentTool == ToolType.Fill)
+            {
+                PerformFill(canvasPoint, currentStrokeColor);
+                FinalizeDrawing();
+            }
+            else if (currentTool == ToolType.ColorPicker)
+            {
+                PickColor(canvasPoint, e.Button);
+                isDrawing = false;
+                hasUnsavedChanges = false;
+            }
+            else if (currentTool == ToolType.Pencil || currentTool == ToolType.Eraser)
+            {
+                DrawBrushStroke(canvasPoint, lastPoint, currentStrokeColor);
+            }
+            else
+            {
+                UpdateOverlayShape(canvasPoint);
+            }
+
+            RefreshCanvas();
+        }
+
+        private void canvasView_MouseMove(object? sender, MouseEventArgs e)
+        {
+            Point canvasPoint = ScreenToCanvas(e.Location);
+            statusPositionLabel.Text = $"X:{Math.Clamp(canvasPoint.X, 0, canvas.Width - 1)} Y:{Math.Clamp(canvasPoint.Y, 0, canvas.Height - 1)}";
+
+            if (!isDrawing)
+            {
+                return;
+            }
+
+            canvasPoint = ClampToCanvas(canvasPoint);
+
+            if (currentTool == ToolType.Pencil || currentTool == ToolType.Eraser)
+            {
+                DrawBrushStroke(canvasPoint, lastPoint, currentStrokeColor);
+                lastPoint = canvasPoint;
+                RefreshCanvas();
+            }
+            else if (currentTool == ToolType.Line || currentTool == ToolType.Rectangle || currentTool == ToolType.Ellipse)
+            {
+                UpdateOverlayShape(canvasPoint);
+                RefreshCanvas();
+            }
+        }
+
+        private void canvasView_MouseUp(object? sender, MouseEventArgs e)
+        {
+            if (!isDrawing)
+            {
+                return;
+            }
+
+            Point canvasPoint = ScreenToCanvas(e.Location);
+            canvasPoint = ClampToCanvas(canvasPoint);
+
+            if (currentTool == ToolType.Line || currentTool == ToolType.Rectangle || currentTool == ToolType.Ellipse)
+            {
+                CommitOverlayShape(canvasPoint, currentStrokeColor);
+            }
+
+            FinalizeDrawing();
+        }
+
+        private void FinalizeDrawing()
+        {
+            overlay?.Dispose();
+            overlay = null;
+            isDrawing = false;
+            hasUnsavedChanges = true;
+            RefreshCanvas();
+        }
+
+        private void UpdateOverlayShape(Point currentPoint)
+        {
+            overlay?.Dispose();
+            overlay = new Bitmap(canvas.Width, canvas.Height);
+
+            using Graphics g = Graphics.FromImage(overlay);
+            g.SmoothingMode = SmoothingMode.None;
+            g.InterpolationMode = InterpolationMode.NearestNeighbor;
+            g.PixelOffsetMode = PixelOffsetMode.Half;
+
+            Rectangle rect = GetRectangle(startPoint, currentPoint);
+            using Brush brush = new SolidBrush(currentStrokeColor);
+            using Pen pen = new Pen(currentStrokeColor, brushSize);
+
+            switch (currentTool)
+            {
+                case ToolType.Line:
+                    pen.StartCap = LineCap.Flat;
+                    pen.EndCap = LineCap.Flat;
+                    g.DrawLine(pen, startPoint, currentPoint);
+                    break;
+                case ToolType.Rectangle:
+                    if (fillShape)
+                    {
+                        g.FillRectangle(brush, rect);
+                    }
+                    g.DrawRectangle(pen, rect);
+                    break;
+                case ToolType.Ellipse:
+                    if (fillShape)
+                    {
+                        g.FillEllipse(brush, rect);
+                    }
+                    g.DrawEllipse(pen, rect);
+                    break;
+            }
+        }
+
+        private void CommitOverlayShape(Point currentPoint, Color color)
+        {
+            overlay ??= new Bitmap(canvas.Width, canvas.Height);
+            using Graphics g = Graphics.FromImage(canvas);
+            g.SmoothingMode = SmoothingMode.None;
+            g.InterpolationMode = InterpolationMode.NearestNeighbor;
+            g.PixelOffsetMode = PixelOffsetMode.Half;
+
+            Rectangle rect = GetRectangle(startPoint, currentPoint);
+            using Brush brush = new SolidBrush(color);
+            using Pen pen = new Pen(color, brushSize) { StartCap = LineCap.Flat, EndCap = LineCap.Flat };
+
+            switch (currentTool)
+            {
+                case ToolType.Line:
+                    g.DrawLine(pen, startPoint, currentPoint);
+                    break;
+                case ToolType.Rectangle:
+                    if (fillShape)
+                    {
+                        g.FillRectangle(brush, rect);
+                    }
+                    g.DrawRectangle(pen, rect);
+                    break;
+                case ToolType.Ellipse:
+                    if (fillShape)
+                    {
+                        g.FillEllipse(brush, rect);
+                    }
+                    g.DrawEllipse(pen, rect);
+                    break;
+            }
+        }
+
+        private void DrawBrushStroke(Point currentPoint, Point previousPoint, Color color)
+        {
+            using Graphics g = Graphics.FromImage(canvas);
+            g.SmoothingMode = SmoothingMode.None;
+            g.InterpolationMode = InterpolationMode.NearestNeighbor;
+            g.PixelOffsetMode = PixelOffsetMode.Half;
+            using SolidBrush brush = new(color);
+            using Pen pen = new(color, brushSize)
+            {
+                StartCap = LineCap.Square,
+                EndCap = LineCap.Square
+            };
+
+            if (currentTool == ToolType.Eraser)
+            {
+                brush.Color = Color.Transparent;
+                pen.Color = Color.Transparent;
+                g.CompositingMode = CompositingMode.SourceCopy;
+            }
+            else
+            {
+                g.CompositingMode = CompositingMode.SourceOver;
+            }
+
+            if (previousPoint == currentPoint)
+            {
+                Rectangle rect = new(currentPoint.X - brushSize / 2, currentPoint.Y - brushSize / 2, brushSize, brushSize);
+                g.FillRectangle(brush, rect);
+            }
+            else
+            {
+                g.DrawLine(pen, previousPoint, currentPoint);
+            }
+        }
+
+        private void PerformFill(Point location, Color color)
+        {
+            Color targetColor = canvas.GetPixel(location.X, location.Y);
+            if (color.ToArgb() == targetColor.ToArgb())
+            {
+                return;
+            }
+
+            Queue<Point> queue = new();
+            queue.Enqueue(location);
+            bool[,] visited = new bool[canvas.Width, canvas.Height];
+            using Graphics g = Graphics.FromImage(canvas);
+            g.CompositingMode = CompositingMode.SourceCopy;
+            using SolidBrush brush = new(color);
+
+            while (queue.Count > 0)
+            {
+                Point point = queue.Dequeue();
+                if (!IsWithinCanvas(point))
+                {
+                    continue;
+                }
+                if (visited[point.X, point.Y])
+                {
+                    continue;
+                }
+                visited[point.X, point.Y] = true;
+                if (canvas.GetPixel(point.X, point.Y).ToArgb() != targetColor.ToArgb())
+                {
+                    continue;
+                }
+
+                Rectangle fillRect = new(point.X, point.Y, 1, 1);
+                g.FillRectangle(brush, fillRect);
+
+                queue.Enqueue(new Point(point.X + 1, point.Y));
+                queue.Enqueue(new Point(point.X - 1, point.Y));
+                queue.Enqueue(new Point(point.X, point.Y + 1));
+                queue.Enqueue(new Point(point.X, point.Y - 1));
+            }
+        }
+
+        private void PickColor(Point location, MouseButtons button)
+        {
+            Color sampled = canvas.GetPixel(location.X, location.Y);
+            if (button == MouseButtons.Right)
+            {
+                secondaryColor = sampled;
+            }
+            else
+            {
+                primaryColor = sampled;
+            }
+            UpdateColorPanels();
+        }
+
+        #endregion
+
+        #region Utility Methods
+
+        private static Rectangle GetRectangle(Point start, Point end)
+        {
+            int x = Math.Min(start.X, end.X);
+            int y = Math.Min(start.Y, end.Y);
+            int width = Math.Abs(start.X - end.X);
+            int height = Math.Abs(start.Y - end.Y);
+            width = Math.Max(1, width);
+            height = Math.Max(1, height);
+            return new Rectangle(x, y, width, height);
+        }
+
+        private Point ScreenToCanvas(Point location)
+        {
+            return new Point(
+                (int)Math.Floor(location.X / zoom),
+                (int)Math.Floor(location.Y / zoom));
+        }
+
+        private Point ClampToCanvas(Point location)
+        {
+            int x = Math.Clamp(location.X, 0, canvas.Width - 1);
+            int y = Math.Clamp(location.Y, 0, canvas.Height - 1);
+            return new Point(x, y);
+        }
+
+        private bool IsWithinCanvas(Point point)
+        {
+            return point.X >= 0 && point.Y >= 0 && point.X < canvas.Width && point.Y < canvas.Height;
+        }
+
+        private Color GetActiveColor(MouseButtons button)
+        {
+            if (currentTool == ToolType.Eraser)
+            {
+                return Color.Transparent;
+            }
+            return button == MouseButtons.Right ? secondaryColor : primaryColor;
+        }
+
+        private void SaveUndoState()
+        {
+            Bitmap snapshot = (Bitmap)canvas.Clone();
+            undoStack.Push(snapshot);
+            TrimStack(undoStack, 50);
+        }
+
+        private void RestoreFromStack(Stack<Bitmap> sourceStack, Stack<Bitmap> destinationStack)
+        {
+            if (sourceStack.Count == 0)
+            {
+                return;
+            }
+
+            destinationStack.Push((Bitmap)canvas.Clone());
+            Bitmap snapshot = sourceStack.Pop();
+            canvas.Dispose();
+            canvas = (Bitmap)snapshot.Clone();
+            snapshot.Dispose();
+            overlay?.Dispose();
+            overlay = null;
+            RefreshCanvas();
+            hasUnsavedChanges = true;
+        }
+
+        private void UpdateStatusLabels(Point location)
+        {
+            statusToolLabel.Text = $"Tool: {currentTool}";
+            statusPositionLabel.Text = $"X:{location.X} Y:{location.Y}";
+        }
+
+        private void ResetZoom()
+        {
+            zoom = Math.Max(0.25f, Math.Min(8f, MathF.Round((float)canvasContainer.Width / canvas.Width, 2)));
+            if (float.IsNaN(zoom) || zoom <= 0f)
+            {
+                zoom = 1f;
+            }
+            zoom = Math.Clamp(zoom, 0.25f, 8f);
+            RefreshCanvas();
+        }
+
+        private void SetZoom(float newZoom)
+        {
+            zoom = Math.Clamp(newZoom, 0.25f, 16f);
+            RefreshCanvas();
+        }
+
+        private DialogResult ConfirmDiscardChanges()
+        {
+            if (!hasUnsavedChanges)
+            {
+                return DialogResult.Yes;
+            }
+
+            return MessageBox.Show(this, "The current sprite has unsaved changes. Continue?", "Unsaved Changes",
+                MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+        }
+
+        #endregion
+
+        #region Toolstrip Events
+
+        private void toolButton_Click(object? sender, EventArgs e)
+        {
+            if (sender is ToolStripButton button)
+            {
+                ToolType tool = toolButtons.First(pair => pair.Value == button).Key;
+                UpdateToolSelection(tool);
+            }
+        }
+
+        private void UpdateToolSelection(ToolType tool)
+        {
+            currentTool = tool;
+            foreach ((ToolType toolType, ToolStripButton button) in toolButtons)
+            {
+                button.Checked = toolType == tool;
+            }
+            statusToolLabel.Text = $"Tool: {currentTool}";
+        }
+
+        private void brushSizeComboBox_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (int.TryParse(brushSizeComboBox.SelectedItem?.ToString(), out int size))
+            {
+                brushSize = size;
+            }
+        }
+
+        private void fillShapeToolStripButton_CheckedChanged(object? sender, EventArgs e)
+        {
+            fillShape = fillShapeToolStripButton.Checked;
+        }
+
+        private void zoomPreset_Click(object? sender, EventArgs e)
+        {
+            if (sender is ToolStripMenuItem item && item.Text.EndsWith('%'))
+            {
+                if (int.TryParse(item.Text.TrimEnd('%'), out int value))
+                {
+                    SetZoom(value / 100f);
+                }
+            }
+        }
+
+        private void zoomInToolStripMenuItem_Click(object? sender, EventArgs e) => SetZoom(zoom * 1.25f);
+        private void zoomOutToolStripMenuItem_Click(object? sender, EventArgs e) => SetZoom(zoom / 1.25f);
+        private void resetZoomToolStripMenuItem_Click(object? sender, EventArgs e) => SetZoom(1f);
+        private void toggleGridToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            showGrid = !showGrid;
+            RefreshCanvas();
+        }
+
+        private void swapColorsToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            (primaryColor, secondaryColor) = (secondaryColor, primaryColor);
+            UpdateColorPanels();
+        }
+
+        private void choosePrimaryColorToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            colorDialog.Color = primaryColor;
+            if (colorDialog.ShowDialog(this) == DialogResult.OK)
+            {
+                primaryColor = colorDialog.Color;
+                UpdateColorPanels();
+            }
+        }
+
+        private void chooseSecondaryColorToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            colorDialog.Color = secondaryColor;
+            if (colorDialog.ShowDialog(this) == DialogResult.OK)
+            {
+                secondaryColor = colorDialog.Color;
+                UpdateColorPanels();
+            }
+        }
+
+        #endregion
+
+        #region File Operations
+
+        private void newCanvasToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            if (ConfirmDiscardChanges() != DialogResult.Yes)
+            {
+                return;
+            }
+
+            using var dialog = new NewCanvasDialog();
+            if (dialog.ShowDialog(this) == DialogResult.OK)
+            {
+                InitializeCanvas(dialog.CanvasWidth, dialog.CanvasHeight);
+                RefreshCanvas();
+            }
+        }
+
+        private void openToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            if (ConfirmDiscardChanges() != DialogResult.Yes)
+            {
+                return;
+            }
+
+            using OpenFileDialog dialog = new()
+            {
+                Filter = "Image Files|*.png;*.bmp;*.gif;*.jpg;*.jpeg|All Files|*.*"
+            };
+            if (dialog.ShowDialog(this) == DialogResult.OK)
+            {
+                try
+                {
+                    using Bitmap loaded = new(dialog.FileName);
+                    InitializeCanvas(loaded.Width, loaded.Height);
+                    using Graphics g = Graphics.FromImage(canvas);
+                    g.DrawImage(loaded, 0, 0);
+                    currentFilePath = dialog.FileName;
+                    hasUnsavedChanges = false;
+                    Text = $"Sprite Editor - {Path.GetFileName(currentFilePath)}";
+                    RefreshCanvas();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, $"Failed to load image: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        private void saveToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            if (!string.IsNullOrEmpty(currentFilePath))
+            {
+                SaveToFile(currentFilePath);
+            }
+            else
+            {
+                saveAsToolStripMenuItem_Click(sender, e);
+            }
+        }
+
+        private void saveAsToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            using SaveFileDialog dialog = new()
+            {
+                Filter = "PNG Image|*.png|Bitmap Image|*.bmp|JPEG Image|*.jpg;*.jpeg"
+            };
+            if (dialog.ShowDialog(this) == DialogResult.OK)
+            {
+                SaveToFile(dialog.FileName);
+                currentFilePath = dialog.FileName;
+                Text = $"Sprite Editor - {Path.GetFileName(currentFilePath)}";
+            }
+        }
+
+        private void SaveToFile(string filePath)
+        {
+            try
+            {
+                canvas.Save(filePath);
+                hasUnsavedChanges = false;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, $"Failed to save image: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void undoToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            RestoreFromStack(undoStack, redoStack);
+        }
+
+        private void redoToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            RestoreFromStack(redoStack, undoStack);
+        }
+
+        private void clearCanvasToolStripMenuItem_Click(object? sender, EventArgs e)
+        {
+            if (MessageBox.Show(this, "Clear the canvas?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            {
+                SaveUndoState();
+                using Graphics g = Graphics.FromImage(canvas);
+                g.Clear(Color.Transparent);
+                hasUnsavedChanges = true;
+                RefreshCanvas();
+            }
+        }
+
+        #endregion
+
+        #region Color Panel Events
+
+        private void primaryColorPanel_Click(object? sender, EventArgs e)
+        {
+            choosePrimaryColorToolStripMenuItem_Click(sender, e);
+        }
+
+        private void secondaryColorPanel_Click(object? sender, EventArgs e)
+        {
+            chooseSecondaryColorToolStripMenuItem_Click(sender, e);
+        }
+
+        #endregion
+
+        private void SpriteEditorForm_FormClosing(object? sender, FormClosingEventArgs e)
+        {
+            if (ConfirmDiscardChanges() == DialogResult.No)
+            {
+                e.Cancel = true;
+                return;
+            }
+
+            overlay?.Dispose();
+            canvas.Dispose();
+            ClearStack(undoStack);
+            ClearStack(redoStack);
+        }
+
+        private static void ClearStack(Stack<Bitmap> stack)
+        {
+            while (stack.Count > 0)
+            {
+                stack.Pop().Dispose();
+            }
+        }
+
+        private static void TrimStack(Stack<Bitmap> stack, int maxItems)
+        {
+            if (stack.Count <= maxItems)
+            {
+                return;
+            }
+
+            Bitmap[] buffer = stack.ToArray();
+            stack.Clear();
+
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                if (i >= maxItems)
+                {
+                    buffer[i].Dispose();
+                }
+            }
+
+            for (int i = Math.Min(maxItems, buffer.Length) - 1; i >= 0; i--)
+            {
+                stack.Push(buffer[i]);
+            }
+        }
+    }
+}

--- a/SPHMMaker/SpriteEditorForm.resx
+++ b/SPHMMaker/SpriteEditorForm.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
## Summary
- add a dedicated Sprite Editor form with painting, fill, shape, color management, zoom, and undo/redo tools
- introduce a new canvas dialog to quickly create sprites at common resolutions
- hook the editor into the main window via the Tools menu and update help text to mention it

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de97ed52e883319422c97e7a5032d1