### PR TITLE
Add item list images with rarity borders

### DIFF
--- a/SPHMMaker/MainForm.Designer.cs
+++ b/SPHMMaker/MainForm.Designer.cs
@@ -15,10 +15,16 @@ namespace SPHMMaker
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                if (components != null)
+                {
+                    components.Dispose();
+                }
+
+                DisposeItemImages();
             }
+
             base.Dispose(disposing);
         }
 
@@ -175,12 +181,15 @@ namespace SPHMMaker
             // 
             // items
             // 
+            items.DrawMode = DrawMode.OwnerDrawFixed;
             items.FormattingEnabled = true;
-            items.ItemHeight = 15;
+            items.IntegralHeight = false;
+            items.ItemHeight = 56;
             items.Location = new Point(582, 30);
             items.Name = "items";
             items.Size = new Size(202, 364);
             items.TabIndex = 1;
+            items.DrawItem += items_DrawItem;
             items.MouseDoubleClick += items_MouseDoubleClick;
             // 
             // itemNameLabel

--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using SPHMMaker.Items;
@@ -7,6 +10,24 @@ namespace SPHMMaker
     public partial class MainForm : Form
     {
         public static MainForm Instance;
+        const int ItemImageSize = 48;
+        const int ItemHorizontalPadding = 8;
+        const int ItemVerticalPadding = 4;
+        static readonly string[] SupportedImageExtensions = new[] { ".png", ".jpg", ".jpeg", ".bmp" };
+
+        readonly Dictionary<string, Image> itemImageCache = new();
+        readonly Image defaultItemImage;
+        bool imagesDisposed;
+
+        static readonly IReadOnlyDictionary<ItemData.ItemQuality, Color> ItemQualityColors = new Dictionary<ItemData.ItemQuality, Color>
+        {
+            { ItemData.ItemQuality.Poor, Color.DimGray },
+            { ItemData.ItemQuality.Common, Color.WhiteSmoke },
+            { ItemData.ItemQuality.Uncommon, Color.MediumSeaGreen },
+            { ItemData.ItemQuality.Rare, Color.RoyalBlue },
+            { ItemData.ItemQuality.Epic, Color.MediumPurple },
+            { ItemData.ItemQuality.Legendary, Color.Orange }
+        };
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         static extern bool AllocConsole();
@@ -17,6 +38,7 @@ namespace SPHMMaker
         public MainForm()
         {
             Instance = this;
+            defaultItemImage = CreateDefaultItemImage();
             InitializeComponent();
             AllocConsole();
 
@@ -50,6 +72,191 @@ namespace SPHMMaker
             }
 
             ItemManager.Load(path + "\\Items");
+        }
+
+        private void items_DrawItem(object? sender, DrawItemEventArgs e)
+        {
+            if (e.Index < 0 || e.Index >= items.Items.Count)
+            {
+                return;
+            }
+
+            bool isSelected = (e.State & DrawItemState.Selected) == DrawItemState.Selected;
+            Color backgroundColor = isSelected ? SystemColors.Highlight : items.BackColor;
+            Color textColor = isSelected ? SystemColors.HighlightText : items.ForeColor;
+
+            using (SolidBrush backgroundBrush = new(backgroundColor))
+            {
+                e.Graphics.FillRectangle(backgroundBrush, e.Bounds);
+            }
+
+            if (items.Items[e.Index] is not ItemData item)
+            {
+                TextRenderer.DrawText(e.Graphics, items.Items[e.Index].ToString() ?? string.Empty, e.Font, e.Bounds, textColor, TextFormatFlags.VerticalCenter | TextFormatFlags.Left);
+                e.DrawFocusRectangle();
+                return;
+            }
+
+            Rectangle imageRect = CalculateImageRectangle(e.Bounds);
+            Image image = GetItemImage(item);
+            e.Graphics.DrawImage(image, imageRect);
+
+            Rectangle borderRect = Rectangle.Inflate(imageRect, 1, 1);
+            using (Pen borderPen = new(GetQualityColor(item.Quality), 2f))
+            {
+                e.Graphics.DrawRectangle(borderPen, borderRect);
+            }
+
+            Rectangle textRect = new(imageRect.Right + ItemHorizontalPadding, e.Bounds.Y, e.Bounds.Width - imageRect.Width - (ItemHorizontalPadding * 2), e.Bounds.Height);
+            TextRenderer.DrawText(e.Graphics, item.Name, e.Font, textRect, textColor, TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+
+            e.DrawFocusRectangle();
+        }
+
+        static Rectangle CalculateImageRectangle(Rectangle bounds)
+        {
+            int availableHeight = Math.Max(bounds.Height - (ItemVerticalPadding * 2), 1);
+            int size = Math.Min(ItemImageSize, availableHeight);
+            int imageY = bounds.Y + ((bounds.Height - size) / 2);
+            return new Rectangle(bounds.X + ItemHorizontalPadding, imageY, size, size);
+        }
+
+        Image GetItemImage(ItemData item)
+        {
+            if (item.GfxPath == null || string.IsNullOrWhiteSpace(item.GfxPath.Name))
+            {
+                return defaultItemImage;
+            }
+
+            string cacheKey = item.GfxPath.ToString();
+
+            if (itemImageCache.TryGetValue(cacheKey, out Image? cachedImage))
+            {
+                return cachedImage;
+            }
+
+            foreach (string candidate in GetCandidatePaths(item))
+            {
+                if (!TryLoadImage(candidate, out Image? loadedImage))
+                {
+                    continue;
+                }
+
+                itemImageCache[cacheKey] = loadedImage;
+                return loadedImage;
+            }
+
+            itemImageCache[cacheKey] = defaultItemImage;
+            return defaultItemImage;
+        }
+
+        static IEnumerable<string> GetCandidatePaths(ItemData item)
+        {
+            if (item.GfxPath == null)
+            {
+                yield break;
+            }
+
+            string relativePath = item.GfxPath.ToString();
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+            yield return Path.Combine(baseDirectory, relativePath);
+            yield return Path.Combine(baseDirectory, "Gfx", relativePath);
+            yield return Path.Combine(baseDirectory, item.GfxPath.Type.ToString(), item.GfxPath.Name);
+            yield return Path.Combine(baseDirectory, "Gfx", item.GfxPath.Type.ToString(), item.GfxPath.Name);
+        }
+
+        static bool TryLoadImage(string basePath, out Image? image)
+        {
+            if (TryLoadImageCore(basePath, out image))
+            {
+                return true;
+            }
+
+            foreach (string extension in SupportedImageExtensions)
+            {
+                string candidate = basePath + extension;
+                if (TryLoadImageCore(candidate, out image))
+                {
+                    return true;
+                }
+            }
+
+            image = null;
+            return false;
+        }
+
+        static bool TryLoadImageCore(string path, out Image? image)
+        {
+            if (!File.Exists(path))
+            {
+                image = null;
+                return false;
+            }
+
+            try
+            {
+                image = Image.FromFile(path);
+                return true;
+            }
+            catch (Exception)
+            {
+                image = null;
+                return false;
+            }
+        }
+
+        static Image CreateDefaultItemImage()
+        {
+            Bitmap bitmap = new(ItemImageSize, ItemImageSize);
+
+            using (Graphics graphics = Graphics.FromImage(bitmap))
+            {
+                graphics.Clear(Color.FromArgb(48, 48, 48));
+
+                using Font font = new(FontFamily.GenericSansSerif, 18, FontStyle.Bold, GraphicsUnit.Pixel);
+                using SolidBrush brush = new(Color.LightGray);
+                using StringFormat format = new()
+                {
+                    Alignment = StringAlignment.Center,
+                    LineAlignment = StringAlignment.Center
+                };
+
+                graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+                graphics.DrawString("?", font, brush, new RectangleF(0, 0, ItemImageSize, ItemImageSize), format);
+            }
+
+            return bitmap;
+        }
+
+        static Color GetQualityColor(ItemData.ItemQuality quality)
+        {
+            if (ItemQualityColors.TryGetValue(quality, out Color color))
+            {
+                return color;
+            }
+
+            return Color.White;
+        }
+
+        void DisposeItemImages()
+        {
+            if (imagesDisposed)
+            {
+                return;
+            }
+
+            foreach (Image image in itemImageCache.Values)
+            {
+                if (!ReferenceEquals(image, defaultItemImage))
+                {
+                    image.Dispose();
+                }
+            }
+
+            defaultItemImage.Dispose();
+            itemImageCache.Clear();
+            imagesDisposed = true;
         }
 
         private void saveDatapackToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- render the item list with owner-drawn thumbnails framed by the item's rarity color
- cache and load item artwork with a fallback placeholder when assets are missing
- dispose cached images when the form closes to prevent resource leaks

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68de987371908331ab0072e51fca05f6