### PR TITLE
Fix loot tab dependencies and namespace structure

### DIFF
--- a/SPHMMaker/Loot/LootEntry.cs
+++ b/SPHMMaker/Loot/LootEntry.cs
@@ -1,7 +1,7 @@
-namespace SPHMMaker.Loot;
-
 using System;
 using System.ComponentModel;
+
+namespace SPHMMaker.Loot;
 
 public class LootEntry : INotifyPropertyChanged
 {
@@ -58,5 +58,4 @@ public class LootEntry : INotifyPropertyChanged
 
     private void OnPropertyChanged(string propertyName) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
 }

--- a/SPHMMaker/Loot/LootManager.cs
+++ b/SPHMMaker/Loot/LootManager.cs
@@ -1,9 +1,9 @@
-namespace SPHMMaker.Loot;
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+
+namespace SPHMMaker.Loot;
 
 public static class LootManager
 {

--- a/SPHMMaker/Loot/LootProbability.cs
+++ b/SPHMMaker/Loot/LootProbability.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace SPHMMaker.Loot
 {
     public static class LootProbability
@@ -14,7 +17,7 @@ namespace SPHMMaker.Loot
                 throw new ArgumentOutOfRangeException(nameof(killCount));
             }
 
-            double p = Math.Clamp(entry.DropChance, 0d, 1d);
+            double p = Math.Clamp(entry.DropRate, 0d, 1d);
             List<LootProbabilityPoint> result = new(killCount + 1);
 
             for (int i = 0; i <= killCount; i++)

--- a/SPHMMaker/Loot/LootTable.cs
+++ b/SPHMMaker/Loot/LootTable.cs
@@ -1,7 +1,6 @@
+using System.ComponentModel;
 
 namespace SPHMMaker.Loot;
-
-using System.ComponentModel;
 
 public class LootTable : INotifyPropertyChanged
 {

--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -10,11 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Windows.Forms.DataVisualization" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Windows.Forms.DataVisualization" />
+    <PackageReference Include="System.Windows.Forms.DataVisualization" Version="7.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- move loot data classes' using directives before their file-scoped namespaces to compile correctly
- fix the loot probability helper to use the DropRate property and add required framework usings
- reference the available System.Windows.Forms.DataVisualization package version so designer types resolve

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68debe37bdbc833182a08c7ce692c52f