### PR TITLE
Fix System.Windows.Forms.DataVisualization NuGet reference

### DIFF
--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Windows.Forms.DataVisualization" Version="7.0.0" />
+    <PackageReference Include="System.Windows.Forms.DataVisualization" Version="1.0.0-prerelease.20110.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update System.Windows.Forms.DataVisualization package reference to the available prerelease version to allow restore on .NET 8

## Testing
- dotnet restore SPHMMaker.sln *(fails: dotnet CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def01ac4cc83318df0ca576253773e