### PR TITLE
Restore spawn zone editor declarations

### DIFF
--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -42,6 +42,34 @@ namespace SPHMMaker
         private readonly BindingSource lootEntryBinding = new();
         private LootTable? activeLootTable;
 
+        readonly BindingList<UnitData> unitDefinitions = new();
+        readonly BindingList<SpawnZoneData> spawnZoneDefinitions = new();
+        readonly BindingSource unitBindingSource = new();
+        readonly BindingSource spawnZoneBindingSource = new();
+        readonly BindingSource assignmentBindingSource = new();
+
+        TabPage? spawnZoneTabPage;
+        ListBox? unitDataListBox;
+        Label? selectedUnitLabel;
+        TextBox? unitNameInput;
+        NumericUpDown? unitLevelSetter;
+        TextBox? unitNotesInput;
+        Button? createUnitButton;
+        Button? updateUnitButton;
+        Button? deleteUnitButton;
+        ListBox? spawnZoneListBox;
+        Label? selectedZoneLabel;
+        TextBox? spawnZoneNameInput;
+        TextBox? spawnZoneNotesInput;
+        Button? createSpawnZoneButton;
+        Button? updateSpawnZoneButton;
+        Button? deleteSpawnZoneButton;
+        ListBox? spawnZoneAssignmentsListBox;
+        NumericUpDown? assignmentMinimumSetter;
+        NumericUpDown? assignmentMaximumSetter;
+        Button? assignUnitButton;
+        Button? removeAssignmentButton;
+
 
 
         public MainForm()
@@ -54,6 +82,9 @@ namespace SPHMMaker
             InitializeItems();
 
             InitializeLootTab();
+
+            InitializeSpawnZoneTab();
+            InitializeSpawnZoneDataBindings();
         }
 
         private void InitializeLootTab()


### PR DESCRIPTION
## Summary
- add backing fields for the spawn zone editor controls and data bindings
- initialize the spawn zone tab and data bindings when the form is created

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68def91c9cf483318b7e02772b8ce2be