### PR TITLE
Fix loot table ID handling

### DIFF
--- a/SPHMMaker/Loot/LootManager.cs
+++ b/SPHMMaker/Loot/LootManager.cs
@@ -9,7 +9,7 @@ public static class LootManager
 {
     public static BindingList<LootTable> LootTables { get; } = new();
 
-    public static LootTable Create(string id)
+    public static LootTable Create(int id)
     {
         LootTable table = new()
         {
@@ -25,8 +25,8 @@ public static class LootManager
         LootTables.Remove(table);
     }
 
-    public static bool ContainsId(string id) =>
-        LootTables.Any(table => table.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+    public static bool ContainsId(int id) =>
+        LootTables.Any(table => table.Id == id);
 
-    public static IEnumerable<string> GetIds() => LootTables.Select(table => table.Id);
+    public static IEnumerable<int> GetIds() => LootTables.Select(table => table.Id);
 }

--- a/SPHMMaker/Loot/LootTable.cs
+++ b/SPHMMaker/Loot/LootTable.cs
@@ -4,7 +4,7 @@ namespace SPHMMaker.Loot;
 
 public class LootTable : INotifyPropertyChanged
 {
-    private string id = string.Empty;
+    private int id;
 
     public LootTable()
     {
@@ -13,7 +13,7 @@ public class LootTable : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public string Id
+    public int Id
     {
         get => id;
         set
@@ -30,7 +30,7 @@ public class LootTable : INotifyPropertyChanged
 
     public BindingList<LootEntry> Entries { get; }
 
-    public override string ToString() => Id;
+    public override string ToString() => Id.ToString();
 
     private void OnPropertyChanged(string propertyName) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -197,11 +197,19 @@ namespace SPHMMaker
 
         private void lootAddTableButton_Click(object? sender, EventArgs e)
         {
-            string id = lootTableIdTextBox.Text.Trim();
+            string idText = lootTableIdTextBox.Text.Trim();
+            int id;
 
-            if (string.IsNullOrEmpty(id))
+            if (string.IsNullOrEmpty(idText))
             {
                 id = CreateDefaultLootTableId();
+            }
+            else if (!int.TryParse(idText, out id))
+            {
+                MessageBox.Show("Loot table ID must be a whole number.", "Invalid ID", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                lootTableIdTextBox.Focus();
+                lootTableIdTextBox.SelectAll();
+                return;
             }
             else if (LootManager.ContainsId(id))
             {
@@ -223,16 +231,24 @@ namespace SPHMMaker
                 return;
             }
 
-            string id = lootTableIdTextBox.Text.Trim();
+            string idText = lootTableIdTextBox.Text.Trim();
 
-            if (string.IsNullOrEmpty(id))
+            if (string.IsNullOrEmpty(idText))
             {
                 MessageBox.Show("Loot table ID cannot be empty.", "Missing ID", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 lootTableIdTextBox.Focus();
                 return;
             }
 
-            if (!string.Equals(activeLootTable.Id, id, StringComparison.OrdinalIgnoreCase) && LootManager.ContainsId(id))
+            if (!int.TryParse(idText, out int id))
+            {
+                MessageBox.Show("Loot table ID must be a whole number.", "Invalid ID", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                lootTableIdTextBox.Focus();
+                lootTableIdTextBox.SelectAll();
+                return;
+            }
+
+            if (activeLootTable.Id != id && LootManager.ContainsId(id))
             {
                 MessageBox.Show("A loot table with that ID already exists.", "Duplicate ID", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
@@ -317,7 +333,7 @@ namespace SPHMMaker
                 lootAddEntryButton.Enabled = true;
                 lootKillsCounter.Enabled = true;
 
-                lootTableIdTextBox.Text = activeLootTable.Id;
+                lootTableIdTextBox.Text = activeLootTable.Id.ToString();
                 lootEntryBinding.DataSource = activeLootTable.Entries;
                 activeLootTable.Entries.ListChanged += LootEntries_ListChanged;
                 lootEntryBinding.ResetBindings(false);
@@ -445,18 +461,16 @@ namespace SPHMMaker
             return result;
         }
 
-        private static string CreateDefaultLootTableId()
+        private static int CreateDefaultLootTableId()
         {
             int index = 1;
-            string id;
 
-            do
+            while (LootManager.ContainsId(index))
             {
-                id = $"loot_table_{index++}";
+                index++;
             }
-            while (LootManager.ContainsId(id));
 
-            return id;
+            return index;
         }
 
         private void DetachFromActiveLootTable()


### PR DESCRIPTION
## Summary
- validate loot table IDs by parsing the text input as integers when creating or saving tables
- update the loot manager and loot table model to use integer IDs consistently
- generate default loot table IDs by finding the next available numeric value

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df1e4125e483319cadaa92f74c60d5