### PR TITLE
Fix duplicate loot grid initialization

### DIFF
--- a/SPHMMaker/MainForm.Designer.cs
+++ b/SPHMMaker/MainForm.Designer.cs
@@ -215,9 +215,6 @@ namespace SPHMMaker
             itemEffectTab.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)tileMovementCostInput).BeginInit();
             ((System.ComponentModel.ISupportInitialize)tileIdInput).BeginInit();
-
-            lootTabPage.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)lootEntriesGrid).BeginInit();
             menuStrip1.SuspendLayout();
             SuspendLayout();
             // 
@@ -1572,9 +1569,6 @@ namespace SPHMMaker
             TilesPageTab.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)tileMovementCostInput).EndInit();
             ((System.ComponentModel.ISupportInitialize)tileIdInput).EndInit();
-            lootTabPage.ResumeLayout(false);
-            lootTabPage.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)lootEntriesGrid).EndInit();
             menuStrip1.ResumeLayout(false);
             menuStrip1.PerformLayout();
             ResumeLayout(false);

--- a/Virtual.md
+++ b/Virtual.md
@@ -219,9 +219,16 @@ Unique compiler and runtime error messages, enriched with details where availabl
     - **Reason:** `spawnZoneDefinitions` is referenced without a declaration in scope, indicating a missing field or property.  
     - **Fix:** Declare the `spawnZoneDefinitions` collection/property or reference the actual data structure that holds the spawn zone definitions.
 
-32. The name 'assignmentBindingSource' does not exist in the current context  
-    - **Code:** CS0103  
-    - **File:** MainForm.cs  
-    - **Line:** 1370, 1371, 1376, 1422, 1437  
-    - **Reason:** The binding source for assignments is not declared, so the compiler cannot find `assignmentBindingSource`.  
+32. The name 'assignmentBindingSource' does not exist in the current context
+    - **Code:** CS0103
+    - **File:** MainForm.cs
+    - **Line:** 1370, 1371, 1376, 1422, 1437
+    - **Reason:** The binding source for assignments is not declared, so the compiler cannot find `assignmentBindingSource`.
     - **Fix:** Define the binding source in the designer or update the code to reference the existing assignments binding component.
+
+33. Exception Unhandled: "BeginInit" has already been called without an "EndInit"
+    - **Type:** System.InvalidOperationException
+    - **File:** MainForm.Designer.cs
+    - **Line:** ~170-180 and ~1510-1520
+    - **Reason:** Prior revisions emitted two `BeginInit()` calls for `lootEntriesGrid` (and matching duplicate `EndInit()`/`ResumeLayout()` calls) whenever `InitializeComponent()` executed. The extra `BeginInit()` was injected after `lootTabPage.SuspendLayout()` was called a second time, leaving the grid in an unfinished initialization state and raising the `InvalidOperationException` at runtime.
+    - **Fix:** Remove the redundant `lootTabPage.SuspendLayout()` / `lootEntriesGrid.BeginInit()` block and the mirrored `ResumeLayout()` / `EndInit()` calls at the bottom of the method so that the grid is initialized exactly once. The remaining `BeginInit()` at ~173 and `EndInit()` at ~1513 now form a balanced pair, allowing the form to load normally.


### PR DESCRIPTION
## Summary
- remove the extra lootTabPage suspend block that re-invoked lootEntriesGrid.BeginInit
- drop the mirrored ResumeLayout/EndInit calls so the grid finishes initialization once
- document the resolved root cause and fix steps for Virtual.md error entry 33

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df213dcbd48331a7be6e10e9ca318e