### PR TITLE
Add datapack archive load and save support

### DIFF
--- a/SPHMMaker/Datapacks/DatapackArchive.cs
+++ b/SPHMMaker/Datapacks/DatapackArchive.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace SPHMMaker
+{
+    internal static class DatapackArchive
+    {
+        public static (string ExtractionRoot, string DatapackRoot) ExtractToTemporaryDirectory(string archivePath)
+        {
+            if (!File.Exists(archivePath))
+            {
+                throw new FileNotFoundException("Archive not found.", archivePath);
+            }
+
+            string extractionRoot = Path.Combine(Path.GetTempPath(), "SPHMMaker", "datapacks", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(extractionRoot);
+
+            ZipFile.ExtractToDirectory(archivePath, extractionRoot);
+
+            string? datapackRoot = FindDatapackRoot(extractionRoot);
+            if (datapackRoot is null)
+            {
+                throw new InvalidDataException("The archive does not contain an Items directory.");
+            }
+
+            return (extractionRoot, datapackRoot);
+        }
+
+        public static void CreateArchive(string sourceDirectory, string destinationArchivePath)
+        {
+            if (!Directory.Exists(sourceDirectory))
+            {
+                throw new DirectoryNotFoundException($"Source directory not found: {sourceDirectory}");
+            }
+
+            if (File.Exists(destinationArchivePath))
+            {
+                File.Delete(destinationArchivePath);
+            }
+
+            ZipFile.CreateFromDirectory(sourceDirectory, destinationArchivePath, CompressionLevel.Optimal, includeBaseDirectory: false);
+        }
+
+        static string? FindDatapackRoot(string directory)
+        {
+            if (Directory.Exists(Path.Combine(directory, "Items")))
+            {
+                return directory;
+            }
+
+            foreach (string child in Directory.GetDirectories(directory))
+            {
+                string? candidate = FindDatapackRoot(child);
+                if (candidate != null)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/SPHMMaker/Items/ItemManager.cs
+++ b/SPHMMaker/Items/ItemManager.cs
@@ -1,158 +1,299 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using System.IO;
-using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Data;
-using Newtonsoft.Json;
-using System.Diagnostics.Eventing.Reader;
-using System.Diagnostics;
-using SPHMMaker.Items.SubTypes;
 using System.Windows.Forms;
+using Newtonsoft.Json;
+using SPHMMaker.Items.SubTypes;
 
 namespace SPHMMaker.Items
 {
     internal static class ItemManager
     {
-        static JsonSerializerSettings serializerSettings = new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto, ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor };
+        static readonly JsonSerializerSettings serializerSettings = new()
+        {
+            TypeNameHandling = TypeNameHandling.Auto,
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
+        };
+
+        static readonly StringComparer PathComparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+        static List<ItemData> items = new();
+        static List<string> itemFileNames = new();
+        static ListBox? itemListBox;
+
         public static ItemData GetItem(string aName) => items.First(x => x.Name == aName);
-        public static bool FreeIdCheck(int aId) => items.Where(x => x.ID == aId).Count() == 0;
-        public static ItemData GetItemById(int id) => items[id]; //TODO: Make sure that items can only be changed in the list and in the Listbox at the same time.
-        //TODO: Also make up ur mind, is id always going to be index?
+        public static bool FreeIdCheck(int aId) => items.All(x => x.ID != aId);
+        public static ItemData GetItemById(int id) => items[id];
         public static ReadOnlyCollection<ItemData> Items => items.AsReadOnly();
-        static List<ItemData> items;
-        static ListBox itemListBox;
+
+        static ItemManager()
+        {
+            CreateDir();
+        }
 
         public static void CreateItem(ItemData aItem)
         {
             items.Add(aItem);
-            itemListBox.DataSource = null;
-            itemListBox.DataSource = items;
+            string relativePath = EnsureUniqueRelativeItemPath(GenerateItemFileName(aItem));
+            itemFileNames.Add(relativePath);
+            RefreshListBox();
         }
 
-        public static void OverrideItem(int aIdToOverride, ItemData aItem)
+        public static void OverrideItem(int index, ItemData aItem)
         {
-            items[aIdToOverride] = aItem;
-            //itemListBox.DataSource = null;
-            //itemListBox.DataSource = items;
+            if (index < 0 || index >= items.Count)
+            {
+                return;
+            }
+
+            items[index] = aItem;
+
+            string folder = GetFolderNameForItem(aItem);
+            string existingPath = itemFileNames.Count > index ? itemFileNames[index] : string.Empty;
+            string fileName = Path.GetFileName(existingPath);
+
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                fileName = GenerateItemFileName(aItem, includeFolder: false);
+            }
+            else
+            {
+                fileName = $"{aItem.ID}_{SanitizeFileName(aItem.Name)}.json";
+            }
+
+            string relativePath = Path.Combine(folder, fileName);
+            itemFileNames[index] = EnsureUniqueRelativeItemPath(relativePath, index);
+            RefreshListBox();
         }
 
         public static void SetListBox(ListBox aItemListBox)
         {
             itemListBox = aItemListBox;
+            RefreshListBox();
+        }
+
+        static void RefreshListBox()
+        {
+            if (itemListBox == null)
+            {
+                return;
+            }
+
+            itemListBox.DataSource = null;
             itemListBox.DataSource = items;
         }
 
-        static ItemManager()
+        [MemberNotNull(nameof(items))]
+        static void CreateList(string path)
         {
-            CreateDir();
-            //CreateList();
-            //listBox = MainForm.Instance.Controls.Find("items", true).First() as ListBox;
-        }
-
-        [MemberNotNull("items")]
-        static void CreateList(string aPath)
-        {
-            items = new List<ItemData>();
-            string[] subTypes = Directory.GetDirectories(aPath);
-            //Directory.GetDirectoryRoot(aPath);
-
-            if (subTypes.Length == 0) throw new DirectoryNotFoundException();
-
-            for (int i = 0; i < subTypes.Length; i++)
+            if (!Directory.Exists(path))
             {
-
-                var x = subTypes.ToList();
-                x.AddRange(Directory.GetDirectories(subTypes[i]));
-                subTypes = x.ToArray();
+                throw new DirectoryNotFoundException();
             }
 
-            foreach (string path in subTypes)
+            string[] files = Directory.GetFiles(path, "*.json", SearchOption.AllDirectories);
+            if (files.Length == 0)
             {
-                string[] items = Directory.GetFiles(path);
-                if (items.Length == 0 && Directory.GetDirectories(path).Count() == 0) throw new FileNotFoundException();
-
-                foreach (string item in items)
-                {
-                    ConvertToItemDataAndAddToList(item);
-                }
+                throw new FileNotFoundException();
             }
 
+            var loadedItems = new List<(ItemData Item, string RelativePath)>();
 
-            items.Sort((x, y) => x.ID - y.ID);
+            foreach (string file in files)
+            {
+                ItemData item = ConvertToItemData(file);
+                string relative = NormalizeRelativePath(Path.GetRelativePath(path, file));
+                loadedItems.Add((item, relative));
+            }
 
-            
+            loadedItems.Sort((left, right) => left.Item.ID.CompareTo(right.Item.ID));
+
+            items = new List<ItemData>(loadedItems.Count);
+            itemFileNames = new List<string>(loadedItems.Count);
+
+            foreach (var entry in loadedItems)
+            {
+                Debug.Assert(items.All(x => x.ID != entry.Item.ID), "Duplicate ID's found");
+                items.Add(entry.Item);
+                itemFileNames.Add(entry.RelativePath);
+            }
         }
 
-        static void ConvertToItemDataAndAddToList(string filePath)
+        static ItemData ConvertToItemData(string filePath)
         {
-            ItemData? i;
             string rawData = File.ReadAllText(filePath);
-            string[] split = filePath.Split("\\");
-            switch (split[split.Length - 2])
-            {
-                case "Consumable":
-                    i = JsonConvert.DeserializeObject<ConsumableData>(rawData, serializerSettings);
-                    break;
-                case "Potion":
-                    i = JsonConvert.DeserializeObject<PotionData>(rawData, serializerSettings);
-                    break;
-                case "Equipment":
-                    i = JsonConvert.DeserializeObject<EquipmentData>(rawData, serializerSettings);
-                    break;
-                case "Weapon":
-                    i = JsonConvert.DeserializeObject<WeaponData>(rawData, serializerSettings);
-                    break;
-                case "Container":
-                    i = JsonConvert.DeserializeObject<BagData>(rawData, serializerSettings);
-                    break;
-                case "Trash":
-                    i = JsonConvert.DeserializeObject<ItemData>(rawData, serializerSettings);
-                    break;
-                default:
-                    throw new WrongDirectoryException();
-            }
-            if (i == null) throw new FileLoadException();
+            string? parentDirectory = Path.GetFileName(Path.GetDirectoryName(filePath));
 
-            Debug.Assert(items.Where(x => x.ID == i.ID).Count() == 0, "Duplicate ID's found");
-            items.Add(i);
+            ItemData? item = parentDirectory switch
+            {
+                "Consumable" => JsonConvert.DeserializeObject<ConsumableData>(rawData, serializerSettings),
+                "Potion" => JsonConvert.DeserializeObject<PotionData>(rawData, serializerSettings),
+                "Equipment" => JsonConvert.DeserializeObject<EquipmentData>(rawData, serializerSettings),
+                "Weapon" => JsonConvert.DeserializeObject<WeaponData>(rawData, serializerSettings),
+                "Container" => JsonConvert.DeserializeObject<BagData>(rawData, serializerSettings),
+                "Trash" => JsonConvert.DeserializeObject<ItemData>(rawData, serializerSettings),
+                _ => throw new WrongDirectoryException(),
+            };
+
+            if (item == null)
+            {
+                throw new FileLoadException();
+            }
+
+            return item;
         }
 
         static void CreateDir()
         {
-            if (Directory.Exists("Items")) return;
-
-            Directory.CreateDirectory("Items");
-
+            if (!Directory.Exists("Items"))
+            {
+                Directory.CreateDirectory("Items");
+            }
         }
 
-        public static bool Save(string aFilePath)
+        public static bool Save(string destination)
         {
-            return false;
+            if (items.Count == 0)
+            {
+                return false;
+            }
+
+            Directory.CreateDirectory(destination);
+            var usedPaths = new HashSet<string>(PathComparer);
+
+            for (int i = 0; i < items.Count; i++)
+            {
+                ItemData item = items[i];
+                string relativePath = itemFileNames.Count > i ? itemFileNames[i] : GenerateItemFileName(item);
+                relativePath = EnsureUniqueRelativeItemPath(relativePath, i, usedPaths);
+
+                string fullPath = Path.Combine(destination, relativePath);
+                string? directory = Path.GetDirectoryName(fullPath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                string json = JsonConvert.SerializeObject(item, Formatting.Indented, serializerSettings);
+                File.WriteAllText(fullPath, json);
+
+                usedPaths.Add(relativePath);
+                if (itemFileNames.Count > i)
+                {
+                    itemFileNames[i] = relativePath;
+                }
+                else
+                {
+                    itemFileNames.Add(relativePath);
+                }
+            }
+
+            return true;
         }
 
-        public static bool Load(string aFilePath)
+        public static bool Load(string path)
         {
+            bool success = true;
             try
             {
-                CreateList(aFilePath);
+                CreateList(path);
             }
             catch (Exception e)
             {
+                success = false;
                 if (e is DirectoryNotFoundException) MessageBox.Show("No subtypes folders found");
                 else if (e is FileNotFoundException) MessageBox.Show("Empty folder found");
                 else if (e is WrongDirectoryException) MessageBox.Show("Weird Directory Found");
                 else throw;
             }
 
-            itemListBox.DataSource = items;
-            return true;
+            RefreshListBox();
+            return success;
+        }
+
+        static string GenerateItemFileName(ItemData item, bool includeFolder = true)
+        {
+            string fileName = $"{item.ID}_{SanitizeFileName(item.Name)}.json";
+            if (!includeFolder)
+            {
+                return fileName;
+            }
+
+            string folder = GetFolderNameForItem(item);
+            return Path.Combine(folder, fileName);
+        }
+
+        static string GetFolderNameForItem(ItemData item) => item switch
+        {
+            WeaponData => "Weapon",
+            PotionData => "Potion",
+            ConsumableData => "Consumable",
+            EquipmentData => "Equipment",
+            BagData => "Container",
+            _ => "Trash",
+        };
+
+        static string SanitizeFileName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return "item";
+            }
+
+            char[] invalid = Path.GetInvalidFileNameChars();
+            var builder = new StringBuilder(name.Length);
+
+            foreach (char c in name)
+            {
+                builder.Append(invalid.Contains(c) ? '_' : c);
+            }
+
+            string sanitized = builder.ToString().Trim();
+            return string.IsNullOrEmpty(sanitized) ? "item" : sanitized;
+        }
+
+        static string NormalizeRelativePath(string relativePath) => relativePath
+            .Replace('\\', Path.DirectorySeparatorChar)
+            .Replace('/', Path.DirectorySeparatorChar);
+
+        static string EnsureUniqueRelativeItemPath(string relativePath, int currentIndex = -1, HashSet<string>? usedPaths = null)
+        {
+            relativePath = NormalizeRelativePath(relativePath);
+            string directory = Path.GetDirectoryName(relativePath) ?? string.Empty;
+            string baseName = Path.GetFileNameWithoutExtension(relativePath);
+            string extension = Path.GetExtension(relativePath);
+
+            HashSet<string> tracker = usedPaths ?? new HashSet<string>(PathComparer);
+            if (usedPaths == null)
+            {
+                for (int i = 0; i < itemFileNames.Count; i++)
+                {
+                    if (i == currentIndex)
+                    {
+                        continue;
+                    }
+
+                    tracker.Add(NormalizeRelativePath(itemFileNames[i]));
+                }
+            }
+
+            string candidate = relativePath;
+            int counter = 1;
+            while (!tracker.Add(candidate))
+            {
+                string suffix = $"_{counter++}";
+                string newFileName = baseName + suffix + extension;
+                candidate = string.IsNullOrEmpty(directory) ? newFileName : Path.Combine(directory, newFileName);
+            }
+
+            return candidate;
         }
     }
-
 
     [Serializable]
     public class WrongDirectoryException : Exception

--- a/SPHMMaker/Tiles/TileManager.cs
+++ b/SPHMMaker/Tiles/TileManager.cs
@@ -1,7 +1,8 @@
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Windows.Forms;
 using Newtonsoft.Json;
 
@@ -15,7 +16,10 @@ namespace SPHMMaker.Tiles
             TypeNameHandling = TypeNameHandling.None
         };
 
+        private static readonly StringComparer PathComparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
         private static List<TileData> tiles = new();
+        private static List<string> tileFileNames = new();
         private static ListBox? tileListBox;
 
         public static ReadOnlyCollection<TileData> Tiles => tiles.AsReadOnly();
@@ -29,7 +33,8 @@ namespace SPHMMaker.Tiles
         public static void CreateTile(TileData tile)
         {
             tiles.Add(tile);
-            tiles = tiles.OrderBy(t => t.ID).ToList();
+            tileFileNames.Add(EnsureUniqueTileFileName(GenerateTileFileName(tile)));
+            SortTiles();
             RefreshDataSource();
         }
 
@@ -41,7 +46,10 @@ namespace SPHMMaker.Tiles
             }
 
             tiles[index] = tile;
-            tiles = tiles.OrderBy(t => t.ID).ToList();
+            string fileName = tileFileNames.Count > index ? tileFileNames[index] : GenerateTileFileName(tile);
+            fileName = EnsureUniqueTileFileName(fileName, index);
+            tileFileNames[index] = fileName;
+            SortTiles();
             RefreshDataSource();
         }
 
@@ -63,6 +71,14 @@ namespace SPHMMaker.Tiles
                 new TileData(4, "Lava", "lava", false, 0, "Deadly lava tile."),
                 new TileData(5, "Snow", "snow", true, 2, "Slows movement slightly."),
             };
+
+            tileFileNames = new List<string>(tiles.Count);
+            var usedNames = new HashSet<string>(PathComparer);
+            foreach (var tile in tiles)
+            {
+                string fileName = EnsureUniqueTileFileName(GenerateTileFileName(tile), usedNames: usedNames);
+                tileFileNames.Add(fileName);
+            }
             RefreshDataSource();
         }
 
@@ -81,14 +97,15 @@ namespace SPHMMaker.Tiles
                 return false;
             }
 
-            var loadedTiles = new List<TileData>();
+            var loadedTiles = new List<(TileData Tile, string FileName)>();
             foreach (var file in files)
             {
                 var rawData = File.ReadAllText(file);
                 var tile = JsonConvert.DeserializeObject<TileData>(rawData, SerializerSettings);
                 if (tile != null)
                 {
-                    loadedTiles.Add(tile);
+                    string relative = Path.GetFileName(file);
+                    loadedTiles.Add((tile, NormalizeFileName(relative)));
                 }
             }
 
@@ -98,8 +115,44 @@ namespace SPHMMaker.Tiles
                 return false;
             }
 
-            tiles = loadedTiles.OrderBy(t => t.ID).ToList();
+            var ordered = loadedTiles.OrderBy(entry => entry.Tile.ID).ToList();
+            tiles = ordered.Select(entry => entry.Tile).ToList();
+            tileFileNames = ordered.Select(entry => entry.FileName).ToList();
             RefreshDataSource();
+            return true;
+        }
+
+        public static bool Save(string destination)
+        {
+            if (tiles.Count == 0)
+            {
+                return false;
+            }
+
+            Directory.CreateDirectory(destination);
+            var usedNames = new HashSet<string>(PathComparer);
+
+            for (int i = 0; i < tiles.Count; i++)
+            {
+                TileData tile = tiles[i];
+                string fileName = tileFileNames.Count > i ? tileFileNames[i] : GenerateTileFileName(tile);
+                fileName = EnsureUniqueTileFileName(fileName, i, usedNames);
+
+                string fullPath = Path.Combine(destination, fileName);
+                string json = JsonConvert.SerializeObject(tile, Formatting.Indented, SerializerSettings);
+                File.WriteAllText(fullPath, json);
+
+                usedNames.Add(fileName);
+                if (tileFileNames.Count > i)
+                {
+                    tileFileNames[i] = fileName;
+                }
+                else
+                {
+                    tileFileNames.Add(fileName);
+                }
+            }
+
             return true;
         }
 
@@ -112,6 +165,73 @@ namespace SPHMMaker.Tiles
 
             tileListBox.DataSource = null;
             tileListBox.DataSource = tiles;
+        }
+
+        private static void SortTiles()
+        {
+            var ordered = tiles
+                .Select((tile, index) => new { Tile = tile, FileName = tileFileNames.Count > index ? tileFileNames[index] : GenerateTileFileName(tile) })
+                .OrderBy(entry => entry.Tile.ID)
+                .ToList();
+
+            tiles = ordered.Select(entry => entry.Tile).ToList();
+            tileFileNames = ordered.Select(entry => entry.FileName).ToList();
+        }
+
+        private static string GenerateTileFileName(TileData tile)
+        {
+            return $"{tile.ID}_{SanitizeFileName(tile.Name)}.json";
+        }
+
+        private static string EnsureUniqueTileFileName(string fileName, int currentIndex = -1, HashSet<string>? usedNames = null)
+        {
+            fileName = NormalizeFileName(fileName);
+            string baseName = Path.GetFileNameWithoutExtension(fileName);
+            string extension = Path.GetExtension(fileName);
+
+            HashSet<string> tracker = usedNames ?? new HashSet<string>(PathComparer);
+            if (usedNames == null)
+            {
+                for (int i = 0; i < tileFileNames.Count; i++)
+                {
+                    if (i == currentIndex)
+                    {
+                        continue;
+                    }
+
+                    tracker.Add(NormalizeFileName(tileFileNames[i]));
+                }
+            }
+
+            string candidate = fileName;
+            int counter = 1;
+            while (!tracker.Add(candidate))
+            {
+                string suffix = $"_{counter++}";
+                candidate = baseName + suffix + extension;
+            }
+
+            return candidate;
+        }
+
+        private static string NormalizeFileName(string name) => name.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+
+        private static string SanitizeFileName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return "tile";
+            }
+
+            char[] invalid = Path.GetInvalidFileNameChars();
+            var builder = new StringBuilder(name.Length);
+            foreach (char c in name)
+            {
+                builder.Append(invalid.Contains(c) ? '_' : c);
+            }
+
+            string sanitized = builder.ToString().Trim();
+            return string.IsNullOrEmpty(sanitized) ? "tile" : sanitized;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a DatapackArchive helper to extract datapack zip files and package updated data
- update MainForm load/save workflows to prompt for archive or folder sources and manage temp directories
- implement save/export routines for item and tile managers with sanitized, unique file naming

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68df347f22448331b69d9952e692b572