### PR TITLE
Ensure tile saving refreshes tracked filenames

### DIFF
--- a/SPHMMaker/Tiles/TileManager.cs
+++ b/SPHMMaker/Tiles/TileManager.cs
@@ -131,6 +131,7 @@ namespace SPHMMaker.Tiles
 
             Directory.CreateDirectory(destination);
             var usedNames = new HashSet<string>(PathComparer);
+            var updatedFileNames = new List<string>(tiles.Count);
 
             for (int i = 0; i < tiles.Count; i++)
             {
@@ -143,16 +144,10 @@ namespace SPHMMaker.Tiles
                 File.WriteAllText(fullPath, json);
 
                 usedNames.Add(fileName);
-                if (tileFileNames.Count > i)
-                {
-                    tileFileNames[i] = fileName;
-                }
-                else
-                {
-                    tileFileNames.Add(fileName);
-                }
+                updatedFileNames.Add(fileName);
             }
 
+            tileFileNames = updatedFileNames;
             return true;
         }
 


### PR DESCRIPTION
## Summary
- refresh the tile filename list while saving tiles to disk to keep it aligned with the tiles collection

## Testing
- dotnet build -p:EnableWindowsTargeting=true *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfefa67d308331ba79bb051fb674e6