### PR TITLE
Remove duplicate loot bindings

### DIFF
--- a/SPHMMaker/LootForm.cs
+++ b/SPHMMaker/LootForm.cs
@@ -8,8 +8,6 @@ namespace SPHMMaker
 {
     public partial class MainForm
     {
-        private readonly BindingSource lootTableBinding = new();
-        private readonly BindingSource lootEntryBinding = new();
         private LootTable? activeLootTable;
 
         private void InitializeLootTab()


### PR DESCRIPTION
## Summary
- remove duplicate loot bindings from LootForm partial so fields exist only once

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dfefa82a2883318146cc93ed46839b