### PR TITLE
Refine loot table ID parsing

### DIFF
--- a/SPHMMaker/LootForm.cs
+++ b/SPHMMaker/LootForm.cs
@@ -123,16 +123,17 @@ namespace SPHMMaker
         private void lootAddTableButton_Click(object? sender, EventArgs e)
         {
             string idText = lootTableIdTextBox.Text.Trim();
+            int id;
             if (string.IsNullOrEmpty(idText))
             {
-                int id = CreateDefaultLootTableId();
+                id = CreateDefaultLootTableId();
                 lootTableIdTextBox.Text = id.ToString();
                 lootTableIdTextBox.Focus();
                 lootTableIdTextBox.SelectAll();
                 return;
             }
 
-            if (!int.TryParse(idText, out int id))
+            if (!int.TryParse(idText, out id))
             {
                 MessageBox.Show("Loot table ID must be a whole number.", "Invalid ID", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 lootTableIdTextBox.Focus();


### PR DESCRIPTION
## Summary
- declare the loot table ID variable before validation to reuse it across branches
- reuse the parsed ID variable to avoid re-declaration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfefa77334833187a3c4a9668f0045