### PR TITLE
Declare editingTile field

### DIFF
--- a/TileForm.cs
+++ b/TileForm.cs
@@ -8,6 +8,7 @@ namespace SPHMMaker
 {
     public partial class MainForm
     {
+        private int editingTile = -1;
         private TileData? FoldDataIntoTile
         {
             get


### PR DESCRIPTION
## Summary
- declare the `editingTile` field on MainForm for tile editing logic

## Testing
- dotnet build *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e011120abc833184fbe9f96719f118