### PR TITLE
Improve spawn zone assignment binding updates

### DIFF
--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -1411,14 +1411,30 @@ namespace SPHMMaker
 
             if (spawnZoneListBox?.SelectedItem is SpawnZoneData zone)
             {
+                SpawnZoneAssignment? currentSelection = spawnZoneAssignmentsListBox.SelectedItem as SpawnZoneAssignment;
+
                 assignmentBindingSource.DataSource = zone.Assignments;
                 spawnZoneAssignmentsListBox.DataSource = assignmentBindingSource;
                 spawnZoneAssignmentsListBox.DisplayMember = nameof(SpawnZoneAssignment.DisplayText);
+                assignmentBindingSource.ResetBindings(false);
+
+                if (currentSelection != null && zone.Assignments.Contains(currentSelection))
+                {
+                    spawnZoneAssignmentsListBox.SelectedItem = currentSelection;
+                    PopulateAssignmentFields(currentSelection);
+                }
+                else
+                {
+                    spawnZoneAssignmentsListBox.ClearSelected();
+                    PopulateAssignmentFields(null);
+                }
             }
             else
             {
                 assignmentBindingSource.DataSource = null;
                 spawnZoneAssignmentsListBox.DataSource = null;
+                spawnZoneAssignmentsListBox.ClearSelected();
+                PopulateAssignmentFields(null);
             }
         }
 


### PR DESCRIPTION
## Summary
- reset the spawn zone assignment binding whenever the selected zone changes
- preserve or clear the assignment selection appropriately to keep the UI state in sync

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0221ed1948331b941c229f3c7e358