### PR TITLE
Fix duplicate MainForm resource inclusion

### DIFF
--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +17,14 @@
 
   <ItemGroup>
     <Compile Include="..\TileForm.cs" Link="TileForm.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="MainForm.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>MainForm.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ExtendedForm\ExtendedCheckedListBox.resx" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- disable default embedded resource globs to avoid duplicate logical resource names
- explicitly include the MainForm and ExtendedCheckedListBox resx files in the project

## Testing
- not run (environment missing dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e0da0ada88833193a5df85dbbf78ab