### PR TITLE
Instantiate markdown editor menu item

### DIFF
--- a/SPHMMaker/MainForm.Designer.cs
+++ b/SPHMMaker/MainForm.Designer.cs
@@ -167,6 +167,7 @@ namespace SPHMMaker
             fileDownloadInstructionsToolStripMenuItem = new ToolStripMenuItem();
             toolsToolStripMenuItem = new ToolStripMenuItem();
             spriteEditorToolStripMenuItem = new ToolStripMenuItem();
+            markdownEditorToolStripMenuItem = new ToolStripMenuItem();
             toolTip1 = new ToolTip(components);
             ((System.ComponentModel.ISupportInitialize)lootDistributionChart).BeginInit();
             ((System.ComponentModel.ISupportInitialize)lootKillsCounter).BeginInit();


### PR DESCRIPTION
## Summary
- instantiate the markdown editor menu item alongside the other ToolStripMenuItems so it exists before being added to the Tools menu

## Testing
- dotnet build SPHMMaker.sln *(fails: command not found: dotnet in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e6dcee4c8331a02a5dd13d887554