### PR TITLE
Fix tools menu initialization crash

### DIFF
--- a/SPHMMaker/MainForm.Designer.cs
+++ b/SPHMMaker/MainForm.Designer.cs
@@ -1477,6 +1477,8 @@ namespace SPHMMaker
             //
             // toolsToolStripMenuItem
             //
+            spriteEditorToolStripMenuItem ??= new ToolStripMenuItem();
+            markdownEditorToolStripMenuItem ??= new ToolStripMenuItem();
             toolsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { spriteEditorToolStripMenuItem, markdownEditorToolStripMenuItem });
             toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             toolsToolStripMenuItem.Size = new Size(48, 20);


### PR DESCRIPTION
## Summary
- ensure the Tools menu initializes its entries before adding them to the dropdown to avoid null references

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0f19437c48331946d2988c393d539