### PR TITLE
Adjust embedded resource configuration

### DIFF
--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
-    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,13 +19,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="ItemForm.resx" />
-    <EmbeddedResource Include="MainForm.resx">
+    <EmbeddedResource Update="ItemForm.resx" />
+    <EmbeddedResource Update="MainForm.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>MainForm.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="ExtendedForm\ExtendedCheckedListBox.resx" />
-    <EmbeddedResource Include="SpriteEditorForm.resx" />
+    <EmbeddedResource Update="ExtendedForm\ExtendedCheckedListBox.resx" />
+    <EmbeddedResource Update="SpriteEditorForm.resx" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- allow the SDK to include default embedded resource items by removing the opt-out property
- convert explicit embedded resource entries to updates so they augment the SDK-provided items

## Testing
- dotnet build SPHMMaker.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1021730b48331919c2b4d35363232