### PR TITLE
Fix duplicate MainForm resource build collision

### DIFF
--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -20,7 +20,8 @@
 
   <ItemGroup>
     <EmbeddedResource Update="ItemForm.resx" />
-    <EmbeddedResource Update="MainForm.resx">
+    <EmbeddedResource Remove="MainForm.resx" />
+    <EmbeddedResource Include="MainForm.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>MainForm.Designer.cs</LastGenOutput>
     </EmbeddedResource>


### PR DESCRIPTION
## Summary
- prevent MainForm.resx from being included twice by removing the default globbed item before re-adding it with custom metadata

## Testing
- not run (environment lacks the .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e10b58e2c483319bca755488219357