### PR TITLE
Fix MainForm.resx embedded resource metadata

### DIFF
--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -20,8 +20,7 @@
 
   <ItemGroup>
     <EmbeddedResource Update="ItemForm.resx" />
-    <EmbeddedResource Remove="MainForm.resx" />
-    <EmbeddedResource Include="MainForm.resx">
+    <EmbeddedResource Update="MainForm.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>MainForm.Designer.cs</LastGenOutput>
     </EmbeddedResource>


### PR DESCRIPTION
## Summary
- replace the explicit removal/inclusion of MainForm.resx with a single Update entry that preserves designer metadata

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e10e2e071c8331ab7e6b65d08f69b9