### PR TITLE
Fix MainForm resource entry

### DIFF
--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -20,9 +20,7 @@
 
   <ItemGroup>
     <EmbeddedResource Update="ItemForm.resx" />
-    <EmbeddedResource Remove="MainForm.resx" />
-
-    <EmbeddedResource Include="MainForm.resx">
+    <EmbeddedResource Update="MainForm.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>MainForm.Designer.cs</LastGenOutput>
     </EmbeddedResource>


### PR DESCRIPTION
## Summary
- restore the MainForm.resx item to a single EmbeddedResource Update entry
- preserve the resource metadata for the form designer output

## Testing
- dotnet build SPHMMaker.sln *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e121464f94833182e78ad4b0ee9993