### PR TITLE
Use inbox Windows Forms charting control

### DIFF
--- a/SPHMMaker/SPHMMaker.csproj
+++ b/SPHMMaker/SPHMMaker.csproj
@@ -10,8 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Windows.Forms.DataVisualization" Version="1.0.0-prerelease.20110.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Windows.Forms.DataVisualization" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- remove the prerelease System.Windows.Forms.DataVisualization package dependency
- rely on the Windows Forms inbox DataVisualization assembly instead

## Testing
- dotnet restore SPHMMaker.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1451b23588331ad8cf4e5e6a6a853