### PR TITLE
Add tool selection dialog for sprite editor

### DIFF
--- a/SPHMMaker/SpriteEditorForm.cs
+++ b/SPHMMaker/SpriteEditorForm.cs
@@ -12,7 +12,7 @@ namespace SPHMMaker
     /// </summary>
     public partial class SpriteEditorForm : Form
     {
-        private enum SpriteTool
+        internal enum SpriteTool
         {
             Brush,
             Eraser,
@@ -177,7 +177,9 @@ namespace SPHMMaker
                 new ToolStripMenuItem("Zoom Out", null, (_, _) => ChangeZoom(0.8f)) { ShortcutKeys = Keys.Control | Keys.Subtract },
                 new ToolStripMenuItem("Reset Zoom", null, (_, _) => ResetZoom()) { ShortcutKeys = Keys.Control | Keys.D0 },
                 new ToolStripSeparator(),
-                new ToolStripMenuItem("Toggle Grid", null, (_, _) => ToggleGrid()) { ShortcutKeys = Keys.Control | Keys.G }
+                new ToolStripMenuItem("Toggle Grid", null, (_, _) => ToggleGrid()) { ShortcutKeys = Keys.Control | Keys.G },
+                new ToolStripSeparator(),
+                new ToolStripMenuItem("Select Tool...", null, OpenToolSelectorDialog)
             });
 
             var imageMenu = new ToolStripMenuItem("Image");
@@ -886,6 +888,15 @@ namespace SPHMMaker
             zoomLevel = 16f;
             zoomLabel.Text = "Zoom: 1600%";
             UpdateCanvasSize();
+        }
+
+        private void OpenToolSelectorDialog(object sender, EventArgs e)
+        {
+            using var dialog = new SpriteToolSelectorDialog(activeTool);
+            if (dialog.ShowDialog(this) == DialogResult.OK)
+            {
+                SelectTool(dialog.SelectedTool);
+            }
         }
 
         private void SelectTool(SpriteTool tool)

--- a/SPHMMaker/SpriteToolSelectorDialog.cs
+++ b/SPHMMaker/SpriteToolSelectorDialog.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace SPHMMaker
+{
+    internal class SpriteToolSelectorDialog : Form
+    {
+        private readonly ListBox toolListBox;
+        private readonly Button okButton;
+        private readonly Button cancelButton;
+        private readonly SpriteEditorForm.SpriteTool defaultTool;
+
+        public SpriteEditorForm.SpriteTool SelectedTool
+        {
+            get
+            {
+                if (toolListBox.SelectedItem is SpriteEditorForm.SpriteTool tool)
+                {
+                    return tool;
+                }
+
+                return defaultTool;
+            }
+        }
+
+        public SpriteToolSelectorDialog(SpriteEditorForm.SpriteTool currentTool)
+        {
+            defaultTool = currentTool;
+
+            Text = "Select Tool";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+            ClientSize = new Size(260, 220);
+
+            var titleLabel = new Label
+            {
+                Text = "Choose a tool:",
+                Location = new Point(12, 12),
+                AutoSize = true
+            };
+
+            toolListBox = new ListBox
+            {
+                Location = new Point(12, 36),
+                Size = new Size(236, 130),
+                IntegralHeight = false,
+                BorderStyle = BorderStyle.FixedSingle
+            };
+            toolListBox.Items.AddRange(Enum.GetValues(typeof(SpriteEditorForm.SpriteTool)).Cast<object>().ToArray());
+            toolListBox.SelectedItem = currentTool;
+            toolListBox.DoubleClick += (_, _) =>
+            {
+                if (toolListBox.SelectedItem != null)
+                {
+                    DialogResult = DialogResult.OK;
+                    Close();
+                }
+            };
+
+            okButton = new Button
+            {
+                Text = "OK",
+                DialogResult = DialogResult.OK,
+                Location = new Point(92, 180),
+                Width = 75
+            };
+
+            cancelButton = new Button
+            {
+                Text = "Cancel",
+                DialogResult = DialogResult.Cancel,
+                Location = new Point(173, 180),
+                Width = 75
+            };
+
+            Controls.Add(titleLabel);
+            Controls.Add(toolListBox);
+            Controls.Add(okButton);
+            Controls.Add(cancelButton);
+
+            AcceptButton = okButton;
+            CancelButton = cancelButton;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a sprite tool selector dialog that lists all available editing tools
- add a View menu entry that opens the dialog and updates the active tool

## Testing
- not run (environment missing `dotnet`)


------
https://chatgpt.com/codex/tasks/task_e_68e14c5502788331a21e27e30b0c60da