### PR TITLE
Aggregate tile metadata into canonical JSON array

### DIFF
--- a/docs/datapack/README.md
+++ b/docs/datapack/README.md
@@ -1,0 +1,36 @@
+# Datapack Overview
+
+## Tile data schema
+
+Tile metadata now uses the richer schema introduced in
+`docs/datapack/Tiles/000*_*.json` files:
+
+```json
+{
+  "ID": 0,
+  "Name": "Example",
+  "Texture": "tile_example",
+  "IsWalkable": true,
+  "MovementCost": 1,
+  "Notes": "Flavor text shown to designers."
+}
+```
+
+## Canonical representation
+
+`docs/datapack/TileData.json` is the aggregated form consumed by tools.
+It contains a JSON array ordered by `ID`. The file replaces the legacy
+newline-delimited representation and should remain valid JSON.
+
+The individual files in `docs/datapack/Tiles/` remain as the authoring
+source for designers because they are easier to edit and review
+individually. Both representations therefore continue to exist: the
+per-tile files are edited by humans, and the aggregated array is
+regenerated for downstream consumption.
+
+## Regenerating `TileData.json`
+
+Use `tools/aggregate_tile_data.py` to rebuild the aggregate file whenever
+per-tile JSON definitions are updated or new tiles are added. The script
+collects the individual definitions, validates that they contain the
+required fields, and writes the combined array back to `TileData.json`.

--- a/docs/datapack/TileData.json
+++ b/docs/datapack/TileData.json
@@ -1,3 +1,74 @@
-{"ID": 0, "Name":"Grass", "Walkable":true, "DragCoeficient":0.6, "Transparent":true}
-{"ID": 1, "Name":"Dirt", "Walkable":true, "DragCoeficient":0.7, "Transparent":true}
-{"ID": 2, "Name":"Wall", "Walkable":false, "DragCoeficient":0, "Transparent":false}
+[
+  {
+    "ID": 0,
+    "Name": "Grassland",
+    "Texture": "tile_grassland",
+    "IsWalkable": true,
+    "MovementCost": 1,
+    "Notes": "Soft meadow sod dotted with clover."
+  },
+  {
+    "ID": 1,
+    "Name": "Packed Dirt",
+    "Texture": "tile_packed_dirt",
+    "IsWalkable": true,
+    "MovementCost": 1,
+    "Notes": "Beaten earth used for well-traveled paths."
+  },
+  {
+    "ID": 2,
+    "Name": "Flagstone",
+    "Texture": "tile_flagstone",
+    "IsWalkable": true,
+    "MovementCost": 1,
+    "Notes": "Evenly hewn stonework lining city plazas."
+  },
+  {
+    "ID": 3,
+    "Name": "River Shore",
+    "Texture": "tile_river_shore",
+    "IsWalkable": true,
+    "MovementCost": 2,
+    "Notes": "Slick stones and reeds edging a flowing river."
+  },
+  {
+    "ID": 4,
+    "Name": "Magma Crust",
+    "Texture": "tile_magma_crust",
+    "IsWalkable": false,
+    "MovementCost": 0,
+    "Notes": "A blistering crust that cracks with molten glow."
+  },
+  {
+    "ID": 5,
+    "Name": "Glacier Ice",
+    "Texture": "tile_glacier_ice",
+    "IsWalkable": true,
+    "MovementCost": 3,
+    "Notes": "A slick sheet of ancient ice that numbs the feet."
+  },
+  {
+    "ID": 6,
+    "Name": "Wildflower Meadow",
+    "Texture": "tile_wildflower_meadow",
+    "IsWalkable": true,
+    "MovementCost": 1,
+    "Notes": "Tall grasses and blooms that sway with the breeze."
+  },
+  {
+    "ID": 7,
+    "Name": "Obsidian Path",
+    "Texture": "tile_obsidian_path",
+    "IsWalkable": true,
+    "MovementCost": 1,
+    "Notes": "Hardened volcanic glass polished smooth by travelers."
+  },
+  {
+    "ID": 8,
+    "Name": "Swamp Bog",
+    "Texture": "tile_swamp_bog",
+    "IsWalkable": false,
+    "MovementCost": 0,
+    "Notes": "Sunken peat that swallows the unwary."
+  }
+]

--- a/tools/aggregate_tile_data.py
+++ b/tools/aggregate_tile_data.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Aggregate tile definitions into a single JSON array.
+
+This script reads every JSON file inside ``docs/datapack/Tiles`` whose
+filename begins with a numeric tile identifier (``000*_``) and maps the
+fields into the canonical tile schema used by ``docs/datapack/TileData.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+ROOT = Path(__file__).resolve().parents[1]
+TILES_DIR = ROOT / "docs" / "datapack" / "Tiles"
+OUTPUT_FILE = ROOT / "docs" / "datapack" / "TileData.json"
+
+
+@dataclass(order=True)
+class TileRecord:
+    """Canonical representation of a tile."""
+
+    ID: int
+    Name: str
+    Texture: str
+    IsWalkable: bool
+    MovementCost: int
+    Notes: str
+
+    @classmethod
+    def from_json(cls, payload: dict) -> "TileRecord":
+        """Create a tile record from a raw JSON mapping."""
+
+        required_fields = {
+            "ID": int,
+            "Name": str,
+            "Texture": str,
+            "IsWalkable": bool,
+            "MovementCost": int,
+            "Notes": str,
+        }
+
+        missing = [key for key in required_fields if key not in payload]
+        if missing:
+            raise ValueError(f"Tile record missing required fields: {missing}")
+
+        # Perform basic type conversion/validation.
+        kwargs = {}
+        for key, expected_type in required_fields.items():
+            value = payload[key]
+            if not isinstance(value, expected_type):
+                raise TypeError(
+                    f"Field '{key}' expected {expected_type.__name__}, got {type(value).__name__}"
+                )
+            kwargs[key] = value
+        return cls(**kwargs)
+
+
+def load_tiles() -> List[TileRecord]:
+    tiles: List[TileRecord] = []
+    for tile_path in sorted(TILES_DIR.glob("000*_*.json")):
+        with tile_path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        tiles.append(TileRecord.from_json(payload))
+    tiles.sort(key=lambda tile: tile.ID)
+    return tiles
+
+
+def write_output(tiles: List[TileRecord]) -> None:
+    data = [tile.__dict__ for tile in tiles]
+    with OUTPUT_FILE.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+
+
+def main() -> None:
+    tiles = load_tiles()
+    write_output(tiles)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adopt the richer tile schema and generate a canonical JSON array for TileData.json
- add a script to aggregate individual tile definitions into the canonical file
- document the schema, regeneration workflow, and why both per-tile and aggregated data remain

## Testing
- `./tools/aggregate_tile_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68e15b036574833185f50e271044a471