### PR TITLE
Support loading aggregate TileData.json files

### DIFF
--- a/SPHMMaker.Tests/SPHMMaker.Tests.csproj
+++ b/SPHMMaker.Tests/SPHMMaker.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SPHMMaker\SPHMMaker.csproj" />
+  </ItemGroup>
+</Project>

--- a/SPHMMaker.Tests/Tiles/TileManagerTests.cs
+++ b/SPHMMaker.Tests/Tiles/TileManagerTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using SPHMMaker.Tiles;
+
+namespace SPHMMaker.Tests.Tiles;
+
+[TestClass]
+public class TileManagerTests
+{
+    [TestMethod]
+    public void Load_FromAggregateFile_PopulatesTilesAndGeneratesFileNames()
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            string aggregatePath = Path.Combine(tempRoot, "TileData.json");
+            var expectedTiles = new List<TileData>
+            {
+                new TileData(5, "Crystal Cavern", "crystal_cavern", true, 1, "Glittering crystals line the walls."),
+                new TileData(2, "Molten Core", "molten_core", false, 0, "Scorching lava flows freely."),
+                new TileData(9, "Ancient Library", "ancient_library", true, 1, "Stacks of dusty tomes."),
+            };
+
+            string aggregateJson = JsonConvert.SerializeObject(expectedTiles, Formatting.Indented);
+            File.WriteAllText(aggregatePath, aggregateJson);
+
+            bool loadResult = TileManager.Load(aggregatePath);
+            Assert.IsTrue(loadResult, "Loading an aggregate TileData.json file should succeed.");
+
+            var orderedExpected = expectedTiles.OrderBy(tile => tile.ID).ToList();
+            var actualTiles = TileManager.Tiles.ToList();
+
+            Assert.AreEqual(orderedExpected.Count, actualTiles.Count, "TileManager should load every entry from the aggregate file.");
+            for (int i = 0; i < orderedExpected.Count; i++)
+            {
+                Assert.AreEqual(orderedExpected[i].ID, actualTiles[i].ID, $"Tile {i} ID did not match.");
+                Assert.AreEqual(orderedExpected[i].Name, actualTiles[i].Name, $"Tile {i} Name did not match.");
+                Assert.AreEqual(orderedExpected[i].Texture, actualTiles[i].Texture, $"Tile {i} Texture did not match.");
+                Assert.AreEqual(orderedExpected[i].IsWalkable, actualTiles[i].IsWalkable, $"Tile {i} walkable flag did not match.");
+                Assert.AreEqual(orderedExpected[i].MovementCost, actualTiles[i].MovementCost, $"Tile {i} movement cost did not match.");
+                Assert.AreEqual(orderedExpected[i].Notes, actualTiles[i].Notes, $"Tile {i} notes did not match.");
+            }
+
+            string saveDestination = Path.Combine(tempRoot, "output");
+            Directory.CreateDirectory(saveDestination);
+            bool saveResult = TileManager.Save(saveDestination);
+            Assert.IsTrue(saveResult, "TileManager.Save should succeed after loading aggregate data.");
+
+            var savedFiles = Directory.GetFiles(saveDestination, "*.json", SearchOption.TopDirectoryOnly)
+                .Select(Path.GetFileName)
+                .OrderBy(name => name)
+                .ToList();
+
+            var expectedFileNames = orderedExpected
+                .Select(tile => GenerateExpectedFileName(tile))
+                .OrderBy(name => name)
+                .ToList();
+
+            CollectionAssert.AreEqual(expectedFileNames, savedFiles, "TileManager should generate stable file names for individual tiles.");
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    private static string GenerateExpectedFileName(TileData tile)
+    {
+        return $"{tile.ID}_{SanitizeFileName(tile.Name)}.json";
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "tile";
+        }
+
+        char[] invalidCharacters = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(name.Length);
+        foreach (char character in name)
+        {
+            builder.Append(invalidCharacters.Contains(character) ? '_' : character);
+        }
+
+        string sanitized = builder.ToString().Trim();
+        return string.IsNullOrEmpty(sanitized) ? "tile" : sanitized;
+    }
+}

--- a/SPHMMaker.sln
+++ b/SPHMMaker.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35208.52
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SPHMMaker", "SPHMMaker\SPHMMaker.csproj", "{37DCF97C-5429-4C11-88AD-309AE2544A43}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SPHMMaker.Tests", "SPHMMaker.Tests\SPHMMaker.Tests.csproj", "{51150633-5695-441B-B115-77D95FE3E59C}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5C618756-D98A-43DD-8C0B-6A8F41FC12B5}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -17,10 +19,14 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{37DCF97C-5429-4C11-88AD-309AE2544A43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{37DCF97C-5429-4C11-88AD-309AE2544A43}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{37DCF97C-5429-4C11-88AD-309AE2544A43}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{37DCF97C-5429-4C11-88AD-309AE2544A43}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {37DCF97C-5429-4C11-88AD-309AE2544A43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {37DCF97C-5429-4C11-88AD-309AE2544A43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {37DCF97C-5429-4C11-88AD-309AE2544A43}.Release|Any CPU.Build.0 = Release|Any CPU
+                {51150633-5695-441B-B115-77D95FE3E59C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {51150633-5695-441B-B115-77D95FE3E59C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {51150633-5695-441B-B115-77D95FE3E59C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {51150633-5695-441B-B115-77D95FE3E59C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/SPHMMaker/Tiles/TileManager.cs
+++ b/SPHMMaker/Tiles/TileManager.cs
@@ -84,6 +84,31 @@ namespace SPHMMaker.Tiles
 
         public static bool Load(string path)
         {
+            if (File.Exists(path) && PathComparer.Equals(Path.GetExtension(path), ".json"))
+            {
+                var rawData = File.ReadAllText(path);
+                var aggregateTiles = JsonConvert.DeserializeObject<List<TileData>>(rawData, SerializerSettings);
+                if (aggregateTiles == null || aggregateTiles.Count == 0)
+                {
+                    LoadDefaults();
+                    return false;
+                }
+
+                var orderedTiles = aggregateTiles.OrderBy(tile => tile.ID).ToList();
+                tiles = orderedTiles.ToList();
+
+                var usedNames = new HashSet<string>(PathComparer);
+                tileFileNames = new List<string>(tiles.Count);
+                foreach (var tile in tiles)
+                {
+                    string fileName = EnsureUniqueTileFileName(GenerateTileFileName(tile), usedNames: usedNames);
+                    tileFileNames.Add(fileName);
+                }
+
+                RefreshDataSource();
+                return true;
+            }
+
             if (!Directory.Exists(path))
             {
                 LoadDefaults();


### PR DESCRIPTION
## Summary
- allow `TileManager.Load` to deserialize aggregate JSON tile lists and generate stable file names
- add a regression test in a new MSTest project to validate loading from a TileData.json aggregate

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e161681b6c83318d7437db039e4b0b