### PR TITLE
Use fixed datapack directory in debug builds

### DIFF
--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -730,6 +730,9 @@ namespace SPHMMaker
 
         private string GetInitialDatapackDirectory()
         {
+#if DEBUG
+            return @"C:\\Users\\Dcxalius\\source\\repos\\Dcxalius\\SPHMMaker\\docs\\datapack";
+#else
             if (string.IsNullOrEmpty(datapackSourcePath))
             {
                 return AppDomain.CurrentDomain.BaseDirectory;
@@ -742,6 +745,7 @@ namespace SPHMMaker
             }
 
             return Directory.Exists(datapackSourcePath) ? datapackSourcePath : AppDomain.CurrentDomain.BaseDirectory;
+#endif
         }
 
         private static void TryDeleteDirectory(string? path)


### PR DESCRIPTION
## Summary
- return the docs datapack directory when building in Debug
- preserve the existing datapack discovery logic for Release builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e165f5a02c833186ded76c7d0c60cf