### PR TITLE
Load tile aggregate file before directory

### DIFF
--- a/TileForm.cs
+++ b/TileForm.cs
@@ -45,7 +45,22 @@ namespace SPHMMaker
         private void InitializeTiles()
         {
             TileManager.SetListBox(tileList);
-            if (!TileManager.Load(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Tiles")))
+
+            string tilesDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Tiles");
+            string aggregatePath = Path.Combine(tilesDirectory, "TileData.json");
+
+            bool loaded = false;
+            if (File.Exists(aggregatePath))
+            {
+                loaded = TileManager.Load(aggregatePath);
+            }
+
+            if (!loaded)
+            {
+                loaded = TileManager.Load(tilesDirectory);
+            }
+
+            if (!loaded)
             {
                 TileManager.LoadDefaults();
             }


### PR DESCRIPTION
## Summary
- add explicit tiles directory and aggregate file paths in InitializeTiles
- try loading the aggregate TileData.json before falling back to the directory or defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1742dbac4833199b78c6a55ac6eb8