### PR TITLE
Enable configurable debug datapack path

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+  </PropertyGroup>
+</Project>

--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -68,6 +68,10 @@ namespace SPHMMaker
         string? datapackRootPath;
         bool datapackLoadedFromArchive;
 
+#if DEBUG
+        private const string DebugDatapackDirectoryEnvironmentVariable = "SPHMMaker_DebugDatapackDirectory";
+#endif
+
 
         public MainForm()
         {
@@ -768,7 +772,27 @@ namespace SPHMMaker
 #if DEBUG
         private static string GetDebugDatapackDirectory()
         {
-            return @"C:\\Users\\Dcxalius\\source\\repos\\Dcxalius\\SPHMMaker\\docs\\datapack";
+            string? configuredPath = Environment.GetEnvironmentVariable(DebugDatapackDirectoryEnvironmentVariable);
+
+            if (!string.IsNullOrWhiteSpace(configuredPath))
+            {
+                string expandedPath = Environment.ExpandEnvironmentVariables(configuredPath).Trim();
+                if (!Directory.Exists(expandedPath))
+                {
+                    throw new DirectoryNotFoundException($"The path configured in the '{DebugDatapackDirectoryEnvironmentVariable}' environment variable does not exist: '{expandedPath}'.");
+                }
+
+                return Path.GetFullPath(expandedPath);
+            }
+
+            string solutionDatapack = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "docs", "datapack"));
+
+            if (Directory.Exists(solutionDatapack))
+            {
+                return solutionDatapack;
+            }
+
+            throw new DirectoryNotFoundException($"Unable to determine the debug datapack directory. Set the '{DebugDatapackDirectoryEnvironmentVariable}' environment variable to a valid path.");
         }
 #endif
 

--- a/docs/datapack/README.md
+++ b/docs/datapack/README.md
@@ -34,3 +34,13 @@ Use `tools/aggregate_tile_data.py` to rebuild the aggregate file whenever
 per-tile JSON definitions are updated or new tiles are added. The script
 collects the individual definitions, validates that they contain the
 required fields, and writes the combined array back to `TileData.json`.
+
+## Debug datapack directory
+
+When running the WinForms tool from source, the application looks for a
+datapack directory during debug builds so file pickers start in a useful
+location. By default it resolves to the repository's
+`docs/datapack` folder. Developers can override this without touching the
+code by setting the `SPHMMaker_DebugDatapackDirectory` environment
+variable to point at an alternate directory on their machine. The path is
+validated during startup to catch typos early.


### PR DESCRIPTION
## Summary
- default builds to the Debug configuration when no configuration is specified
- allow the debug datapack directory to be configured via environment variable with a repository fallback
- document how to override the datapack path during development

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e176e5913483318331e05a67caeae5