### PR TITLE
Handle empty path when preparing Save As dialog

### DIFF
--- a/SPHMMaker/MarkdownEditorForm.cs
+++ b/SPHMMaker/MarkdownEditorForm.cs
@@ -128,7 +128,9 @@ namespace SPHMMaker
             {
                 Filter = "Markdown files (*.md;*.markdown)|*.md;*.markdown|Text files (*.txt)|*.txt|All files (*.*)|*.*",
                 Title = "Save Markdown File",
-                FileName = Path.GetFileName(currentFilePath) ?? string.Empty
+                FileName = string.IsNullOrWhiteSpace(currentFilePath)
+                    ? string.Empty
+                    : Path.GetFileName(currentFilePath)
             };
 
             if (dialog.ShowDialog(this) == DialogResult.OK)


### PR DESCRIPTION
## Summary
- avoid calling Path.GetFileName with a null or whitespace current file path when opening the Save As dialog

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e180485b08833182c9e2b142ad05c9