### PR TITLE
Fix debug datapack directory discovery

### DIFF
--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -782,11 +782,18 @@ namespace SPHMMaker
                 return Path.GetFullPath(expandedPath);
             }
 
-            string solutionDatapack = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "docs", "datapack"));
+            DirectoryInfo? current = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
 
-            if (Directory.Exists(solutionDatapack))
+            while (current != null)
             {
-                return solutionDatapack;
+                string candidate = Path.Combine(current.FullName, "docs", "datapack");
+
+                if (Directory.Exists(candidate))
+                {
+                    return Path.GetFullPath(candidate);
+                }
+
+                current = current.Parent;
             }
 
             throw new DirectoryNotFoundException($"Unable to determine the debug datapack directory. Set the '{DebugDatapackDirectoryEnvironmentVariable}' environment variable to a valid path.");


### PR DESCRIPTION
## Summary
- update the debug datapack resolution to climb parent directories until it finds `docs/datapack`
- retain the environment variable override and throw when no candidate is located

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e192c6781483319c084d786b362816