### PR TITLE
Add centralized datapack save manager and regression tests

### DIFF
--- a/SPHMMaker.Tests/Datapacks/SaveManagerTests.cs
+++ b/SPHMMaker.Tests/Datapacks/SaveManagerTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SPHMMaker.Datapacks;
+using SPHMMaker.Items;
+using SPHMMaker.Tiles;
+
+namespace SPHMMaker.Tests.Datapacks;
+
+[TestClass]
+public class SaveManagerTests
+{
+    [TestInitialize]
+    public void Initialize() => ResetManagers();
+
+    [TestCleanup]
+    public void Cleanup() => ResetManagers();
+
+    [TestMethod]
+    public void SaveToDirectory_WritesItemAndTileSubfolders()
+    {
+        SeedSampleData();
+
+        string exportRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(exportRoot);
+
+        try
+        {
+            SaveManager.SaveToDirectory(exportRoot);
+
+            string itemsDirectory = Path.Combine(exportRoot, "Items");
+            string tilesDirectory = Path.Combine(exportRoot, "Tiles");
+
+            Assert.IsTrue(Directory.Exists(itemsDirectory), "Items directory should be created.");
+            Assert.IsTrue(Directory.Exists(tilesDirectory), "Tiles directory should be created.");
+
+            int itemFileCount = Directory.GetFiles(itemsDirectory, "*.json", SearchOption.AllDirectories).Length;
+            int tileFileCount = Directory.GetFiles(tilesDirectory, "*.json", SearchOption.AllDirectories).Length;
+
+            Assert.IsTrue(itemFileCount > 0, "Item export should produce at least one JSON file.");
+            Assert.IsTrue(tileFileCount > 0, "Tile export should produce at least one JSON file.");
+        }
+        finally
+        {
+            if (Directory.Exists(exportRoot))
+            {
+                Directory.Delete(exportRoot, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void SaveToArchive_CreatesZipWithExportedData()
+    {
+        SeedSampleData();
+
+        string tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        string archivePath = Path.Combine(tempRoot, "datapack.zip");
+
+        try
+        {
+            SaveManager.SaveToArchive(archivePath);
+
+            Assert.IsTrue(File.Exists(archivePath), "Archive should be created.");
+
+            using ZipArchive archive = ZipFile.OpenRead(archivePath);
+            var entryNames = archive.Entries.Select(entry => entry.FullName).ToList();
+
+            Assert.IsTrue(entryNames.Any(name => name.StartsWith("Items/", StringComparison.OrdinalIgnoreCase)), "Archive should contain item data.");
+            Assert.IsTrue(entryNames.Any(name => name.StartsWith("Tiles/", StringComparison.OrdinalIgnoreCase)), "Archive should contain tile data.");
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Save_WhenNoData_ThrowsInvalidOperationException()
+    {
+        string exportRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(exportRoot);
+
+        try
+        {
+            Assert.ThrowsException<InvalidOperationException>(() => SaveManager.SaveToDirectory(exportRoot));
+        }
+        finally
+        {
+            if (Directory.Exists(exportRoot))
+            {
+                Directory.Delete(exportRoot, recursive: true);
+            }
+        }
+
+        string archivePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "datapack.zip");
+        Assert.ThrowsException<InvalidOperationException>(() => SaveManager.SaveToArchive(archivePath));
+    }
+
+    static void SeedSampleData()
+    {
+        ResetManagers();
+
+        var items = new List<ItemData>
+        {
+            new ItemData(1, "sword_icon", "Test Sword", "A reliable testing blade.", 1, ItemData.ItemQuality.Common, 100),
+        };
+
+        var tiles = new List<TileData>
+        {
+            new TileData(1, "Test Tile", "test_tile", true, 1, "Tile used for testing."),
+        };
+
+        SetField(typeof(ItemManager), "items", items);
+        SetField(typeof(ItemManager), "itemFileNames", new List<string>());
+        SetField(typeof(TileManager), "tiles", tiles);
+        SetField(typeof(TileManager), "tileFileNames", new List<string>());
+    }
+
+    static void ResetManagers()
+    {
+        SetField(typeof(ItemManager), "items", new List<ItemData>());
+        SetField(typeof(ItemManager), "itemFileNames", new List<string>());
+        SetField(typeof(TileManager), "tiles", new List<TileData>());
+        SetField(typeof(TileManager), "tileFileNames", new List<string>());
+    }
+
+    static void SetField(Type type, string fieldName, object value)
+    {
+        FieldInfo? field = type.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(field, $"Field '{fieldName}' was not found on type '{type.FullName}'.");
+        field!.SetValue(null, value);
+    }
+}

--- a/SPHMMaker/Datapacks/SaveManager.cs
+++ b/SPHMMaker/Datapacks/SaveManager.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using SPHMMaker.Items;
+using SPHMMaker.Tiles;
+
+namespace SPHMMaker.Datapacks
+{
+    internal static class SaveManager
+    {
+        private static readonly IReadOnlyList<(string Subfolder, Func<string, bool> SaveFunc)> SaveTargets = new List<(string, Func<string, bool>)>
+        {
+            ("Items", ItemManager.Save),
+            ("Tiles", TileManager.Save),
+        };
+
+        public static void SaveToDirectory(string destinationPath)
+        {
+            if (string.IsNullOrWhiteSpace(destinationPath))
+            {
+                throw new ArgumentException("Destination path cannot be null or whitespace.", nameof(destinationPath));
+            }
+
+            Directory.CreateDirectory(destinationPath);
+
+            bool anySaved = false;
+            foreach (var target in SaveTargets)
+            {
+                string subfolderPath = Path.Combine(destinationPath, target.Subfolder);
+                RemoveExistingDirectory(subfolderPath);
+                Directory.CreateDirectory(subfolderPath);
+
+                bool saved = target.SaveFunc(subfolderPath);
+                anySaved |= saved;
+            }
+
+            if (!anySaved)
+            {
+                throw new InvalidOperationException("There is no data to save.");
+            }
+        }
+
+        public static void SaveToArchive(string destinationArchivePath)
+        {
+            if (string.IsNullOrWhiteSpace(destinationArchivePath))
+            {
+                throw new ArgumentException("Destination archive path cannot be null or whitespace.", nameof(destinationArchivePath));
+            }
+
+            string? archiveDirectory = Path.GetDirectoryName(destinationArchivePath);
+            if (!string.IsNullOrEmpty(archiveDirectory))
+            {
+                Directory.CreateDirectory(archiveDirectory);
+            }
+
+            string tempRoot = Path.Combine(Path.GetTempPath(), "SPHMMaker", "export", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+
+            bool anySaved = false;
+            try
+            {
+                foreach (var target in SaveTargets)
+                {
+                    string subfolderPath = Path.Combine(tempRoot, target.Subfolder);
+                    Directory.CreateDirectory(subfolderPath);
+
+                    bool saved = target.SaveFunc(subfolderPath);
+                    anySaved |= saved;
+                }
+
+                if (!anySaved)
+                {
+                    throw new InvalidOperationException("There is no data to save.");
+                }
+
+                DatapackArchive.CreateArchive(tempRoot, destinationArchivePath);
+            }
+            finally
+            {
+                TryDeleteDirectory(tempRoot);
+            }
+        }
+
+        private static void RemoveExistingDirectory(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+            else if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup failures.
+            }
+        }
+    }
+}

--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -4,8 +4,9 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using SPHMMaker.Items;
 using SPHMMaker.Classes;
+using SPHMMaker.Datapacks;
+using SPHMMaker.Items;
 using SPHMMaker.SpawnZones;
 using SPHMMaker.Tiles;
 using SPHMMaker.Loot;
@@ -668,50 +669,11 @@ namespace SPHMMaker
             {
                 if (asArchive)
                 {
-                    string tempRoot = Path.Combine(Path.GetTempPath(), "SPHMMaker", "export", Guid.NewGuid().ToString("N"));
-                    Directory.CreateDirectory(tempRoot);
-
-                    try
-                    {
-                        bool itemsSaved = ItemManager.Save(Path.Combine(tempRoot, "Items"));
-                        bool tilesSaved = TileManager.Save(Path.Combine(tempRoot, "Tiles"));
-
-                        if (!itemsSaved && !tilesSaved)
-                        {
-                            throw new InvalidOperationException("There is no data to save.");
-                        }
-
-                        DatapackArchive.CreateArchive(tempRoot, destinationPath);
-                    }
-                    finally
-                    {
-                        TryDeleteDirectory(tempRoot);
-                    }
+                    SaveManager.SaveToArchive(destinationPath);
                 }
                 else
                 {
-                    Directory.CreateDirectory(destinationPath);
-
-                    string itemsDirectory = Path.Combine(destinationPath, "Items");
-                    string tilesDirectory = Path.Combine(destinationPath, "Tiles");
-
-                    if (Directory.Exists(itemsDirectory))
-                    {
-                        Directory.Delete(itemsDirectory, true);
-                    }
-
-                    if (Directory.Exists(tilesDirectory))
-                    {
-                        Directory.Delete(tilesDirectory, true);
-                    }
-
-                    bool itemsSaved = ItemManager.Save(itemsDirectory);
-                    bool tilesSaved = TileManager.Save(tilesDirectory);
-
-                    if (!itemsSaved && !tilesSaved)
-                    {
-                        throw new InvalidOperationException("There is no data to save.");
-                    }
+                    SaveManager.SaveToDirectory(destinationPath);
                 }
 
                 MessageBox.Show("Datapack saved successfully.", "Save Datapack", MessageBoxButtons.OK, MessageBoxIcon.Information);


### PR DESCRIPTION
## Summary
- introduce a SaveManager for centralised datapack export logic for directories and archives
- refactor MainForm to delegate datapack saving to the new manager
- add regression tests covering directory and archive exports and empty data handling

## Testing
- dotnet test *(fails: dotnet not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a8015ec88331a36e313f953b6e01