### PR TITLE
Set datapack defaults and sprite editor initial directories

### DIFF
--- a/SPHMMaker/MainForm.cs
+++ b/SPHMMaker/MainForm.cs
@@ -68,6 +68,7 @@ namespace SPHMMaker
         string? datapackExtractionRoot;
         string? datapackRootPath;
         bool datapackLoadedFromArchive;
+        private const string DefaultDatapackPath = "C:\\Users\\Dcxalius\\source\\repos\\Dcxalius\\SPHMMaker\\docs\\datapack";
 
 #if DEBUG
         private const string DebugDatapackDirectoryEnvironmentVariable = "SPHMMaker_DebugDatapackDirectory";
@@ -532,82 +533,12 @@ namespace SPHMMaker
 
         private (string? Path, bool IsArchive) PromptForDatapackLoad()
         {
-            return ("C:\\Users\\Dcxalius\\source\\repos\\Dcxalius\\SPHMMaker\\docs\\datapack", false);
-
-
-            DialogResult choice = MessageBox.Show(
-                "Is the datapack stored as a .zip archive?\nChoose Yes to load a .zip file or No to load from an extracted folder.",
-                "Load Datapack",
-                MessageBoxButtons.YesNoCancel,
-                MessageBoxIcon.Question);
-
-            if (choice == DialogResult.Cancel)
-            {
-                return (null, false);
-            }
-
-            if (choice == DialogResult.Yes)
-            {
-                using OpenFileDialog dialog = new()
-                {
-                    Filter = "Datapack archive (*.zip)|*.zip",
-                    Title = "Select Datapack Archive",
-                    InitialDirectory = GetInitialDatapackDirectory()
-                };
-
-                return dialog.ShowDialog() == DialogResult.OK
-                    ? (dialog.FileName, true)
-                    : (null, false);
-            }
-
-            using FolderBrowserDialog folderDialog = new()
-            {
-                Description = "Select Datapack Folder",
-                SelectedPath = GetInitialDatapackDirectory()
-            };
-
-            return folderDialog.ShowDialog() == DialogResult.OK
-                ? (folderDialog.SelectedPath, false)
-                : (null, false);
+            return (DefaultDatapackPath, false);
         }
 
         private (string? Path, bool IsArchive) PromptForDatapackSave()
         {
-            DialogResult choice = MessageBox.Show(
-                "Would you like to save the datapack as a .zip archive?\nChoose Yes for a .zip file or No to export to a folder.",
-                "Save Datapack",
-                MessageBoxButtons.YesNoCancel,
-                MessageBoxIcon.Question);
-
-            if (choice == DialogResult.Cancel)
-            {
-                return (null, false);
-            }
-
-            if (choice == DialogResult.Yes)
-            {
-                using SaveFileDialog dialog = new()
-                {
-                    Filter = "Datapack archive (*.zip)|*.zip",
-                    Title = "Save Datapack",
-                    FileName = GetDefaultDatapackFileName(includeExtension: true),
-                    InitialDirectory = GetInitialDatapackDirectory()
-                };
-
-                return dialog.ShowDialog() == DialogResult.OK
-                    ? (dialog.FileName, true)
-                    : (null, false);
-            }
-
-            using FolderBrowserDialog folderDialog = new()
-            {
-                Description = "Select Folder to Save Datapack",
-                SelectedPath = GetInitialDatapackDirectory()
-            };
-
-            return folderDialog.ShowDialog() == DialogResult.OK
-                ? (folderDialog.SelectedPath, false)
-                : (null, false);
+            return (DefaultDatapackPath, false);
         }
 
         private void LoadDatapack(string path, bool isArchive)

--- a/SPHMMaker/SpriteEditorForm.cs
+++ b/SPHMMaker/SpriteEditorForm.cs
@@ -845,6 +845,7 @@ namespace SPHMMaker
             using (OpenFileDialog dialog = new OpenFileDialog())
             {
                 dialog.Filter = "Image Files|*.png;*.bmp;*.gif;*.jpg;*.jpeg|All Files|*.*";
+                dialog.InitialDirectory = AppDomain.CurrentDomain.BaseDirectory;
                 if (dialog.ShowDialog() == DialogResult.OK)
                 {
                     using (Bitmap loaded = new Bitmap(dialog.FileName))
@@ -874,6 +875,7 @@ namespace SPHMMaker
             {
                 dialog.Filter = "PNG Image|*.png|Bitmap Image|*.bmp";
                 dialog.DefaultExt = "png";
+                dialog.InitialDirectory = AppDomain.CurrentDomain.BaseDirectory;
                 if (dialog.ShowDialog() == DialogResult.OK)
                 {
                     currentFilePath = dialog.FileName;
@@ -888,6 +890,7 @@ namespace SPHMMaker
             {
                 dialog.Filter = "PNG Image|*.png";
                 dialog.DefaultExt = "png";
+                dialog.InitialDirectory = AppDomain.CurrentDomain.BaseDirectory;
                 if (dialog.ShowDialog() == DialogResult.OK)
                 {
                     workingBitmap.Save(dialog.FileName, ImageFormat.Png);


### PR DESCRIPTION
## Summary
- point datapack load/save prompts directly to the repository datapack directory
- default the sprite editor open/save/export dialogs to the application's base directory

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d24a21748331a71bcc36b82d8aa1